### PR TITLE
Initial ECS setup according to current rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{js,json,ts,tsx}]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,15 @@
     "description": "Coding standard used in LMC projects",
     "type": "library",
     "license": "MIT",
-    "minimum-stability": "stable",
+    "minimum-stability": "alpha",
+    "prefer-stable": true,
     "authors": [
         {
             "name": "LMC s.r.o.",
             "homepage": "https://github.com/lmc-eu"
         }
     ],
-    "require": {}
+    "require": {
+        "symplify/easy-coding-standard": "4.0.x"
+    }
 }

--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -1,0 +1,103 @@
+imports:
+    - { resource: 'vendor/symplify/easy-coding-standard/config/psr2.yml' }
+
+services:
+    # Class and Interface names should be unique in a project, they should never be duplicated
+    PHP_CodeSniffer\Standards\Generic\Sniffs\Classes\DuplicateClassNameSniff: ~
+    # Control Structures must have at least one statement inside of the body (empty catch rules is skipped)
+    PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff: ~
+    # For loops that have only a second expression (the condition) should be converted to while loops
+    PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\ForLoopShouldBeWhileLoopSniff: ~
+    # Incrementers in nested loops should use different variable names
+    PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\JumbledIncrementerSniff: ~
+    # If statements that are always evaluated should not be used
+    PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\UnconditionalIfStatementSniff: ~
+    # Methods should not be declared final inside of classes that are declared final
+    PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\UnnecessaryFinalModifierSniff: ~
+    # Methods should not be defined that only call the parent method
+    PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\UselessOverridingMethodSniff: ~
+    # Doc comment formatting (but some of the rules are skipped)
+    PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\DocCommentSniff: ~
+    # Line length should not exceed 120 characters
+    PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff:
+        absoluteLineLimit: 0
+        lineLimit: 120
+    # There should only be one class defined in a file
+    PHP_CodeSniffer\Standards\Generic\Sniffs\Files\OneClassPerFileSniff: ~
+    # There should only be one interface defined in a file
+    PHP_CodeSniffer\Standards\Generic\Sniffs\Files\OneInterfacePerFileSniff: ~
+    # There should only be one trait defined in a file
+    PHP_CodeSniffer\Standards\Generic\Sniffs\Files\OneTraitPerFileSniff: ~
+    # Exactly one space is allowed after a cast
+    PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceAfterCastSniff: ~
+    # Some functions should not appear in the code
+    PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff:
+        forbiddenFunctions:
+            var_dump: null
+            dump: null
+            echo: null
+            require: null
+            require_once: null
+            include: null
+            include_once: null
+            phpinfo: null
+            eval: null
+            printf: null
+    # When referencing arrays you should not put whitespace around the opening bracket or before the closing bracket
+    PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayBracketSpacingSniff: ~
+    # Various array declaration rules (but some of the rules are skipped)
+    PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayDeclarationSniff: ~
+    # The self keyword should be used instead of the current class name
+    PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes\SelfMemberReferenceSniff: ~
+    # The asterisks in a doc comment should align, and there should be one space between the asterisk and tags
+    PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\DocCommentAlignmentSniff: ~
+    # Empty catch statements must have comment explaining why the exception is not handled
+    PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\EmptyCatchCommentSniff: ~
+    # Tests that the ++ operators are used when possible and not used when it makes the code confusing
+    PHP_CodeSniffer\Standards\Squiz\Sniffs\Operators\IncrementDecrementUsageSniff: ~
+    # Verifies that class members have scope modifiers
+    PHP_CodeSniffer\Standards\Squiz\Sniffs\Scope\MemberVarScopeSniff: ~
+    # Casts should not have whitespace inside the parentheses
+    PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\CastSpacingSniff: ~
+    # The php constructs like echo, return, include, etc. should have one space after them
+    PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\LanguageConstructSpacingSniff: ~
+    # Verifies that operators have valid spacing surrounding them
+    PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\LogicalOperatorSpacingSniff: ~
+    # Proper operator spacing
+    PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\OperatorSpacingSniff:
+        ignoreNewlines: true
+    # The php keywords static, public, private, and protected should have one space after them
+    PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ScopeKeywordSpacingSniff: ~
+    # Semicolons should not have spaces before them
+    PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\SemicolonSpacingSniff: ~
+
+parameters:
+    skip:
+         # We allow empty catch statements (but they must have comment - see EmptyCatchCommentSniff)
+        PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff.DetectedCatch: ~
+
+         # Skip unwanted rules from DocCommentSniff
+        PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\DocCommentSniff.ContentAfterOpen: ~
+        PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\DocCommentSniff.ContentBeforeClose: ~
+        PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\DocCommentSniff.MissingShort: ~
+        PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\DocCommentSniff.NonParamGroup: ~
+        PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\DocCommentSniff.ParamGroup: ~
+        PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\DocCommentSniff.ParamNotFirst: ~
+        PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\DocCommentSniff.TagValueIndent: ~
+
+        # Skip unwanted rules from ArrayDeclarationSniff
+        PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayDeclarationSniff.CloseBraceNotAligned: ~
+        PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayDeclarationSniff.DoubleArrowNotAligned: ~
+        PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayDeclarationSniff.KeyNotAligned: ~
+        PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayDeclarationSniff.MultiLineNotAllowed: ~
+        PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayDeclarationSniff.SingleLineNotAllowed: ~
+        PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayDeclarationSniff.ValueNotAligned: ~
+
+         # There could be more than one space after star (eg. in Doctrine annotations)
+        PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\DocCommentAlignmentSniff.SpaceAfterStar: ~
+
+         # Skip non-PSR2 rules incorrectly added by ECS (https://github.com/Symplify/Symplify/issues/696)
+        PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ControlStructureSpacingSniff.LineAfterClose: ~
+        PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ControlStructureSpacingSniff.NoLineAfterClose: ~
+        PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ControlStructureSpacingSniff.SpaceBeforeCloseBrace: ~
+        PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ControlStructureSpacingSniff.SpacingAfterOpenBrace: ~

--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -71,6 +71,90 @@ services:
     # Semicolons should not have spaces before them
     PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\SemicolonSpacingSniff: ~
 
+    PhpCsFixer\Fixer\Alias\MbStrFunctionsFixer: ~
+    PhpCsFixer\Fixer\Alias\NoAliasFunctionsFixer: ~
+    PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer:
+        syntax: short
+    PhpCsFixer\Fixer\ArrayNotation\NormalizeIndexBraceFixer: ~
+    PhpCsFixer\Fixer\ArrayNotation\NoTrailingCommaInSinglelineArrayFixer: ~
+    PhpCsFixer\Fixer\ArrayNotation\TrailingCommaInMultilineArrayFixer: ~
+    PhpCsFixer\Fixer\ArrayNotation\TrimArraySpacesFixer: ~
+    PhpCsFixer\Fixer\ArrayNotation\WhitespaceAfterCommaInArrayFixer: ~
+    PhpCsFixer\Fixer\Basic\BracesFixer:
+        allow_single_line_closure: true
+    PhpCsFixer\Fixer\Basic\Psr4Fixer: ~
+    PhpCsFixer\Fixer\Casing\NativeFunctionCasingFixer: ~
+    PhpCsFixer\Fixer\CastNotation\CastSpacesFixer: ~
+    PhpCsFixer\Fixer\CastNotation\LowercaseCastFixer: ~
+    PhpCsFixer\Fixer\CastNotation\ShortScalarCastFixer: ~
+    PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer:
+        elements:
+            - method
+    PhpCsFixer\Fixer\ClassNotation\NoBlankLinesAfterClassOpeningFixer: ~
+    PhpCsFixer\Fixer\ClassNotation\SelfAccessorFixer: ~
+    PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer: ~
+    PhpCsFixer\Fixer\Comment\NoEmptyCommentFixer: ~
+    PhpCsFixer\Fixer\ControlStructure\NoUselessElseFixer: ~
+    PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer:
+        equal: false
+        identical: false
+        less_and_greater: false
+    PhpCsFixer\Fixer\FunctionNotation\FunctionTypehintSpaceFixer: ~
+    PhpCsFixer\Fixer\FunctionNotation\NoUnreachableDefaultArgumentValueFixer: ~
+    PhpCsFixer\Fixer\Import\NoLeadingImportSlashFixer: ~
+    PhpCsFixer\Fixer\Import\NoUnusedImportsFixer:
+    PhpCsFixer\Fixer\Import\OrderedImportsFixer: ~
+    PhpCsFixer\Fixer\LanguageConstruct\IsNullFixer:
+        use_yoda_style: false
+    PhpCsFixer\Fixer\NamespaceNotation\NoLeadingNamespaceWhitespaceFixer: ~
+    PhpCsFixer\Fixer\NamespaceNotation\SingleBlankLineBeforeNamespaceFixer: ~
+    PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer: ~
+    PhpCsFixer\Fixer\Operator\ConcatSpaceFixer:
+        spacing: one
+    PhpCsFixer\Fixer\Operator\NewWithBracesFixer: ~
+    PhpCsFixer\Fixer\Operator\ObjectOperatorWithoutWhitespaceFixer: ~
+    PhpCsFixer\Fixer\Operator\StandardizeNotEqualsFixer: ~
+    PhpCsFixer\Fixer\Operator\TernaryOperatorSpacesFixer: ~
+    PhpCsFixer\Fixer\Operator\UnaryOperatorSpacesFixer: ~
+    PhpCsFixer\Fixer\Phpdoc\NoBlankLinesAfterPhpdocFixer: ~
+    PhpCsFixer\Fixer\Phpdoc\NoEmptyPhpdocFixer: ~
+    PhpCsFixer\Fixer\Phpdoc\PhpdocAddMissingParamAnnotationFixer: ~
+    PhpCsFixer\Fixer\Phpdoc\PhpdocIndentFixer: ~
+    PhpCsFixer\Fixer\Phpdoc\PhpdocNoAccessFixer: ~
+    PhpCsFixer\Fixer\Phpdoc\PhpdocNoEmptyReturnFixer: ~
+    PhpCsFixer\Fixer\Phpdoc\PhpdocNoPackageFixer: ~
+    PhpCsFixer\Fixer\Phpdoc\PhpdocOrderFixer: ~
+    PhpCsFixer\Fixer\Phpdoc\PhpdocReturnSelfReferenceFixer: ~
+    PhpCsFixer\Fixer\Phpdoc\PhpdocScalarFixer: ~
+    PhpCsFixer\Fixer\Phpdoc\PhpdocSingleLineVarSpacingFixer: ~
+    PhpCsFixer\Fixer\Phpdoc\PhpdocTrimFixer: ~
+    PhpCsFixer\Fixer\Phpdoc\PhpdocTypesFixer: ~
+    PhpCsFixer\Fixer\PhpTag\FullOpeningTagFixer: ~
+    PhpCsFixer\Fixer\PhpUnit\PhpUnitConstructFixer: ~
+    PhpCsFixer\Fixer\PhpUnit\PhpUnitDedicateAssertFixer: ~
+    PhpCsFixer\Fixer\ReturnNotation\NoUselessReturnFixer: ~
+    PhpCsFixer\Fixer\Semicolon\NoEmptyStatementFixer: ~
+    PhpCsFixer\Fixer\Semicolon\NoSinglelineWhitespaceBeforeSemicolonsFixer: ~
+    PhpCsFixer\Fixer\Semicolon\SpaceAfterSemicolonFixer: ~
+    PhpCsFixer\Fixer\StringNotation\SingleQuoteFixer: ~
+    PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer:
+        statements:
+            - return
+            - try
+    PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer:
+        tokens:
+            - break
+            - continue
+            - curly_brace_block
+            - extra
+            - parenthesis_brace_block
+            - return
+            - square_brace_block
+            - throw
+            - use
+            - use_trait
+    PhpCsFixer\Fixer\Whitespace\NoWhitespaceInBlankLineFixer: ~
+
 parameters:
     skip:
          # We allow empty catch statements (but they must have comment - see EmptyCatchCommentSniff)


### PR DESCRIPTION
This is just an initial import of rules currently defined in `lmc/jobs-meta` for both [php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) and [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer/) into Symfon-DI-like yml format which is used by (alpha) version 4 of [Symplify/EasyCodingStandard](https://github.com/Symplify/EasyCodingStandard) (ECS).

The plan is now to make use of `lmc/jobs-meta` for sharing codestyle rules obsolete and switch to ECS instead. As the integration is pretty straightforward, this will make reuse of the codestyle quite easy. ECS support excluding files and/or specific fixers, so it will also be easy to adjust the configuration for edgecases, but still benefit from the standard, well known and unified configuration format.

Codebases currenly using rulesets from `lmc/jobs-meta` should be 99 % compatible with this configuration - attached configuration was tested on few of them (I tried eg. Jobs, ApiBundle, Consentor, Footer API, ApplyFeedback, CompanyProfiles, [matej-client-php](https://github.com/lmc-eu/matej-client-php), [Steward](https://github.com/lmc-eu/steward)...), so this set of rules is already battle-tested.

However what needs to be resolved:
1. Will we sort and/or structure the rules anyhow? Until now we had php-cs-fixer rules sorted alphabetically according to their name (like "array_syntax", "phpdoc_no_empty_return" etc.), which is the current order in easy-coding-standard.yml in this PR. But it does not make any sense now, and will be hard to maintain. Maybe we can sort them now by their FQCN. Yes or no? (Or null? :upside_down_face: )
2. Should the phpcs/PHP_CodeSniffer rules be separated in the configuration like now, or we will simply sort all the services alphabetically by their FQCN?
3. Do we want to use comments explaining each of the rule? (We had them in phpcs-ruleset.xml of `lmc/jobs-meta`, but not in php-cs-fixer-ruleset.php - so for not I kept them in the PHP_CodeSniffer section, until we decide if we want to have them or not).
4. ~PHP 7-specific rules were not yet part of jobs-meta so they are not part of this (yet). But I will add them directly in the main file - if there is anyone still on PHP 5.6, they can simply [skip them](https://github.com/Symplify/EasyCodingStandard#exclude-checkers). Ok?~ ECS requires PHP ^7.1. So we don't plan using this on PHP ^5.6 projects.

Your thoughts?