### PR TITLE
Add few more basic rules mainly for PHP 7.1

### DIFF
--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -73,6 +73,7 @@ services:
 
     PhpCsFixer\Fixer\Alias\MbStrFunctionsFixer: ~
     PhpCsFixer\Fixer\Alias\NoAliasFunctionsFixer: ~
+    PhpCsFixer\Fixer\Alias\RandomApiMigrationFixer: ~
     PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer:
         syntax: short
     PhpCsFixer\Fixer\ArrayNotation\NormalizeIndexBraceFixer: ~
@@ -101,11 +102,16 @@ services:
         less_and_greater: false
     PhpCsFixer\Fixer\FunctionNotation\FunctionTypehintSpaceFixer: ~
     PhpCsFixer\Fixer\FunctionNotation\NoUnreachableDefaultArgumentValueFixer: ~
+    PhpCsFixer\Fixer\FunctionNotation\ReturnTypeDeclarationFixer: ~
+    PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer: ~
     PhpCsFixer\Fixer\Import\NoLeadingImportSlashFixer: ~
     PhpCsFixer\Fixer\Import\NoUnusedImportsFixer:
     PhpCsFixer\Fixer\Import\OrderedImportsFixer: ~
+    PhpCsFixer\Fixer\LanguageConstruct\DeclareEqualNormalizeFixer: ~
     PhpCsFixer\Fixer\LanguageConstruct\IsNullFixer:
         use_yoda_style: false
+    PhpCsFixer\Fixer\ListNotation\ListSyntaxFixer:
+        syntax: short
     PhpCsFixer\Fixer\NamespaceNotation\NoLeadingNamespaceWhitespaceFixer: ~
     PhpCsFixer\Fixer\NamespaceNotation\SingleBlankLineBeforeNamespaceFixer: ~
     PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer: ~
@@ -115,6 +121,7 @@ services:
     PhpCsFixer\Fixer\Operator\ObjectOperatorWithoutWhitespaceFixer: ~
     PhpCsFixer\Fixer\Operator\StandardizeNotEqualsFixer: ~
     PhpCsFixer\Fixer\Operator\TernaryOperatorSpacesFixer: ~
+    PhpCsFixer\Fixer\Operator\TernaryToNullCoalescingFixer: ~
     PhpCsFixer\Fixer\Operator\UnaryOperatorSpacesFixer: ~
     PhpCsFixer\Fixer\Phpdoc\NoBlankLinesAfterPhpdocFixer: ~
     PhpCsFixer\Fixer\Phpdoc\NoEmptyPhpdocFixer: ~
@@ -136,11 +143,14 @@ services:
     PhpCsFixer\Fixer\Semicolon\NoEmptyStatementFixer: ~
     PhpCsFixer\Fixer\Semicolon\NoSinglelineWhitespaceBeforeSemicolonsFixer: ~
     PhpCsFixer\Fixer\Semicolon\SpaceAfterSemicolonFixer: ~
+    PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer: ~
+    PhpCsFixer\Fixer\Strict\StrictParamFixer: ~
     PhpCsFixer\Fixer\StringNotation\SingleQuoteFixer: ~
     PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer:
         statements:
             - return
             - try
+    PhpCsFixer\Fixer\Whitespace\CompactNullableTypehintFixer: ~
     PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer:
         tokens:
             - break
@@ -154,6 +164,14 @@ services:
             - use
             - use_trait
     PhpCsFixer\Fixer\Whitespace\NoWhitespaceInBlankLineFixer: ~
+
+    SlevomatCodingStandard\Sniffs\Exceptions\ReferenceThrowableOnlySniff: ~
+
+    Symplify\CodingStandard\Fixer\Naming\ExceptionNameFixer: ~
+    Symplify\CodingStandard\Fixer\Naming\MagicMethodsNamingFixer: ~
+    Symplify\CodingStandard\Sniffs\Naming\AbstractClassNameSniff: ~
+    Symplify\CodingStandard\Sniffs\Naming\InterfaceNameSniff: ~
+    Symplify\CodingStandard\Sniffs\Naming\TraitNameSniff: ~
 
 parameters:
     skip:


### PR DESCRIPTION
This adds few new rules, not yet enforced by `jobs-meta` by default.

Some of them are however already being used by our PHP 7.1+ projects. And few others (the Symplify ones) enforce rules which we already agreed on (at least in Jobs), but which were not enforced by automatic codestyle check.

Ideas about some other ones (especially those which enforces rules we already use, but are not yet checked). Maybe https://github.com/Symplify/CodingStandard#types-should-not-be-referenced-via-a-fullypartially-qualified-name-but-via-a-use-statement ?

Rules description: https://github.com/Symplify/CodingStandard, https://github.com/slevomat/coding-standard, https://github.com/FriendsOfPHP/PHP-CS-Fixer