### PR TITLE
Make resrouces loading work when using directly or when installed as dependency

### DIFF
--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -1,5 +1,8 @@
 imports:
-    - { resource: 'vendor/symplify/easy-coding-standard/config/psr2.yml' }
+    # Import path when this package is installed as dependency
+    - { resource: '../../easy-coding-standard/config/psr2.yml', ignore_errors: true }
+    # Import path when this package is being used directly (eg. during development)
+    - { resource: 'vendor/symplify/easy-coding-standard/config/psr2.yml', ignore_errors: true }
 
 services:
     # Class and Interface names should be unique in a project, they should never be duplicated


### PR DESCRIPTION
The resource path [is relative to current file](http://symfony.com/doc/current/service_container/import.html#importing-configuration-with-imports).

So when `vendor/bin/ecs check` is run directly from this package (I use it eg. now during its development; also when you try applying new rules to some other codebase etc.), the relative path to the PSR-2 resource file from our `easy-coding-standard.yml` is `./vendor/symplify/easy-coding-standard/config/psr2.yml`.

However when this package itself is installed as dependency of some other package, our `easy-coding-standard.yml` file is now located in `./vendor/lmc/coding-standard/easy-coding-standard.yml`, so if you will try to load `vendor/symplify/easy-coding-standard/config/psr2.yml`, it will not work, because the resource loader will try to load resource relatively to location of the file, ie. `vendor/lmc/coding-standard/vendor/symplify/easy-coding-standard/config/psr2.yml`.

This solution work but feels little bit like a hack, does anyone have a better idea 🤔?