### PR TITLE
Update to ECS 4.0.0 stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,8 @@ We use [EasyCodingStandard] to define and execute checks created for both [PHP-C
 ## Installation
 
 ```bash
-composer require --dev lmc/coding-standard:dev-master symplify/easy-coding-standard:^4.0@alpha symplify/coding-standard:^4.0@alpha symplify/package-builder:^4.0@alpha symplify/token-runner:^4.0@alpha symplify/better-reflection-docblock:^4.0@alpha
+composer require --dev lmc/coding-standard:dev-master
 ```
-
-ℹ️ Because we currently depend on `@alpha` version of [EasyCodingStandard], all of its `@alpha` dependencies must temporarily
-also be explicitly required with their stability flag.
 
 ## Usage
 
@@ -52,7 +49,6 @@ You can configure EasyCodingStandard via `parameters` section of your `easy-codi
  - exclude specific file from all checks (via [`exclude_files`](https://github.com/Symplify/EasyCodingStandard#ignore-what-you-cant-fix))
  - skip specific check from some file(s) or directories (via [`skip`](https://github.com/Symplify/EasyCodingStandard#ignore-what-you-cant-fix))
  - disable whole check (via [`exclude_checkers`](https://github.com/Symplify/EasyCodingStandard#exclude-checkers))
-
 
 ## Changelog
 For latest changes see [CHANGELOG.md](CHANGELOG.md) file. We follow [Semantic Versioning](http://semver.org/).

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "description": "Coding standard used in LMC projects",
     "type": "library",
     "license": "MIT",
-    "minimum-stability": "alpha",
     "prefer-stable": true,
     "authors": [
         {
@@ -12,7 +11,7 @@
         }
     ],
     "require": {
-        "symplify/easy-coding-standard": "4.0.x"
+        "symplify/easy-coding-standard": "^4.0.0"
     },
     "require-dev": {
         "j13k/yaml-lint": "^1.1",

--- a/easy-coding-standard.yaml
+++ b/easy-coding-standard.yaml
@@ -1,8 +1,5 @@
 imports:
-    # Import path when this package is installed as dependency
-    - { resource: '../../easy-coding-standard/config/psr2.yml', ignore_errors: true }
-    # Import path when this package is being used directly (eg. during development)
-    - { resource: 'vendor/symplify/easy-coding-standard/config/psr2.yml', ignore_errors: true }
+    - { resource: '%vendor_dir%/symplify/easy-coding-standard/config/psr2.yml' }
 
 services:
     # Class and Interface names should be unique in a project, they should never be duplicated
@@ -200,9 +197,3 @@ parameters:
 
          # There could be more than one space after star (eg. in Doctrine annotations)
         PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\DocCommentAlignmentSniff.SpaceAfterStar: ~
-
-         # Skip non-PSR2 rules incorrectly added by ECS (https://github.com/Symplify/Symplify/issues/696)
-        PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ControlStructureSpacingSniff.LineAfterClose: ~
-        PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ControlStructureSpacingSniff.NoLineAfterClose: ~
-        PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ControlStructureSpacingSniff.SpaceBeforeCloseBrace: ~
-        PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ControlStructureSpacingSniff.SpacingAfterOpenBrace: ~


### PR DESCRIPTION
https://github.com/Symplify/EasyCodingStandard is now 4.0.0 stable, so we can remove the alpha stuff and use its new features :tada: .

Once this is merged and tested, we can release 1.0.0 and start using this :muscle: .