### PR TITLE
Replace ExceptionNameFixer with more generic ClassNameSuffixByParenFixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+- Replace deprecated `ExceptionNameFixer` with more generic `ClassNameSuffixByParentFixer`.
 
 ## 1.0.0 - 2018-04-03
 - Initial version

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "symplify/easy-coding-standard": "^4.0.0"
+        "symplify/easy-coding-standard": "^4.0.2"
     },
     "require-dev": {
         "j13k/yaml-lint": "^1.1",

--- a/easy-coding-standard.yaml
+++ b/easy-coding-standard.yaml
@@ -167,7 +167,7 @@ services:
 
     SlevomatCodingStandard\Sniffs\Exceptions\ReferenceThrowableOnlySniff: ~
 
-    Symplify\CodingStandard\Fixer\Naming\ExceptionNameFixer: ~
+    Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer: ~
     Symplify\CodingStandard\Fixer\Naming\MagicMethodsNamingFixer: ~
     Symplify\CodingStandard\Sniffs\Naming\AbstractClassNameSniff: ~
     Symplify\CodingStandard\Sniffs\Naming\InterfaceNameSniff: ~


### PR DESCRIPTION
It does not only check Exception classes do have suffix `Exception`, but also does similar checks for [more cases](https://github.com/Symplify/CodingStandard/blob/master/src/Fixer/Naming/ClassNameSuffixByParentFixer.php#L30-L41):

```php
        '*Command' => 'Command',
        '*Controller' => 'Controller',
        '*Repository' => 'Repository',
        '*Presenter' => 'Presenter',
        '*Request' => 'Request',
        '*Response' => 'Response',
        '*EventSubscriber' => 'EventSubscriber',
        '*FixerInterface' => 'Fixer',
        '*Sniff' => 'Sniff',
        '*Exception' => 'Exception',
        '*Handler' => 'Handler',
```

But from quick check we should be already following this conventions in our codebases as well.