### PR TITLE
Add various fixers for PHPUnit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+- Add PHPUnit fixers:
+    - `PhpUnitMockFixer`: Ensure dedicated helper methods `createMock()` and `createPartialMock()` are used where possible instead of `->getMock()`.
+    - `PhpUnitNoExpectationAnnotationFixer`: Use `setExpectedException()` instead of `@expectedException` annotation.
+    - `PhpUnitSetUpTearDownVisibilityFixer`: Visibility of `setUp()` and `tearDown()` method should be kept protected as defined in PHPUnit TestCase.
 
 ## 1.0.1 - 2018-04-09
 - Replace deprecated `ExceptionNameFixer` with more generic `ClassNameSuffixByParentFixer`.

--- a/easy-coding-standard.yaml
+++ b/easy-coding-standard.yaml
@@ -139,6 +139,13 @@ services:
     PhpCsFixer\Fixer\PhpTag\FullOpeningTagFixer: ~
     PhpCsFixer\Fixer\PhpUnit\PhpUnitConstructFixer: ~
     PhpCsFixer\Fixer\PhpUnit\PhpUnitDedicateAssertFixer: ~
+    # Use dedicated helper methods createMock() and createPartialMock() where possible
+    PhpCsFixer\Fixer\PhpUnit\PhpUnitMockFixer: ~
+    # Use expectedException*() methods instead of @expectedException* annotation (both following fixers must be applied to do so)
+    PhpCsFixer\Fixer\PhpUnit\PhpUnitNoExpectationAnnotationFixer: ~
+    PhpCsFixer\Fixer\PhpUnit\PhpUnitExpectationFixer: ~
+    # Visibility of setUp() and tearDown() method should be kept protected
+    PhpCsFixer\Fixer\PhpUnit\PhpUnitSetUpTearDownVisibilityFixer: ~
     PhpCsFixer\Fixer\ReturnNotation\NoUselessReturnFixer: ~
     PhpCsFixer\Fixer\Semicolon\NoEmptyStatementFixer: ~
     PhpCsFixer\Fixer\Semicolon\NoSinglelineWhitespaceBeforeSemicolonsFixer: ~

--- a/yaml-sort-checker.yml
+++ b/yaml-sort-checker.yml
@@ -3,6 +3,8 @@ files:
         depth: 3
         excludedKeys:
             0: parameters
+            services:
+                - PhpCsFixer\Fixer\PhpUnit\PhpUnitExpectationFixer
         excludedSections:
             0: imports
     yaml-sort-checker.yml:


### PR DESCRIPTION
- `PhpUnitMockFixer`: Ensure dedicated helper methods `createMock()` and `createPartialMock()` are used where possible instead of `->getMock()`.
- `PhpUnitNoExpectationAnnotationFixer`: Use `setExpectedException()` instead of `@expectedException` annotation (see https://thephp.cc/news/2016/02/questioning-phpunit-best-practices)
- `PhpUnitSetUpTearDownVisibilityFixer`: Visibility of `setUp()` and `tearDown()` method should be kept protected as defined in PHPUnit TestCase.