### PR TITLE
Do not check EventSubscriber class suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     - `PhpUnitMockFixer`: Ensure dedicated helper methods `createMock()` and `createPartialMock()` are used where possible instead of `->getMock()`.
     - `PhpUnitNoExpectationAnnotationFixer`: Use `setExpectedException()` instead of `@expectedException` annotation.
     - `PhpUnitSetUpTearDownVisibilityFixer`: Visibility of `setUp()` and `tearDown()` method should be kept protected as defined in PHPUnit TestCase.
+- Do not check for `EventSubscriber` class suffixes via `ClassNameSuffixByParentFixer`.
 
 ## 1.0.1 - 2018-04-09
 - Replace deprecated `ExceptionNameFixer` with more generic `ClassNameSuffixByParentFixer`.

--- a/easy-coding-standard.yaml
+++ b/easy-coding-standard.yaml
@@ -174,7 +174,18 @@ services:
 
     SlevomatCodingStandard\Sniffs\Exceptions\ReferenceThrowableOnlySniff: ~
 
-    Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer: ~
+    Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer:
+        parent_types_to_suffixes:
+            '*Command': 'Command'
+            '*Controller': 'Controller'
+            '*Repository': 'Repository'
+            '*Presenter': 'Presenter'
+            '*Request': 'Request'
+            '*Response': 'Response'
+            '*FixerInterface': 'Fixer'
+            '*Sniff': 'Sniff'
+            '*Exception': 'Exception'
+            '*Handler': 'Handler'
     Symplify\CodingStandard\Fixer\Naming\MagicMethodsNamingFixer: ~
     Symplify\CodingStandard\Sniffs\Naming\AbstractClassNameSniff: ~
     Symplify\CodingStandard\Sniffs\Naming\InterfaceNameSniff: ~


### PR DESCRIPTION
Class implementing `EventSubscriberInterface` are named `...Listener` (eg. in symfony codebase), or `...Subscriber`. But usually not `...EventSubscriber`.

And I don't think we can now agree on the same suffix which will fit all (or can we?), so lets remove this check for now.

(This PR overwrites the [default settings](https://github.com/Symplify/CodingStandard/blob/master/src/Fixer/Naming/ClassNameSuffixByParentFixer.php#L37) of the fixer, and effectively removing just the check for EventSubscriber)