### PR TITLE
Fix false positives on one-line annotations with PHP_CS 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
+## Unreleased
+- Fix `Generic.Commenting.DocComment.SpacingBeforeTags` being reported on one-line phpDoc annotations (when PHP_Codesniffer 3.3.0+ is used).
+
 ## 1.1.0 - 2018-05-14
 - Add `SpecifyArgSeparatorFixer` to make sure arg_separator is always defined when using `http_build_query()` function.
 - Add PHPUnit fixers:

--- a/easy-coding-standard.yaml
+++ b/easy-coding-standard.yaml
@@ -206,6 +206,7 @@ parameters:
         PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\DocCommentSniff.NonParamGroup: ~
         PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\DocCommentSniff.ParamGroup: ~
         PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\DocCommentSniff.ParamNotFirst: ~
+        PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\DocCommentSniff.SpacingBeforeTags: ~
         PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\DocCommentSniff.TagValueIndent: ~
 
         # Skip unwanted rules from ArrayDeclarationSniff


### PR DESCRIPTION
PHP_CodeSniffer 3.3.0 was just released, and behavior of `Generic.Commenting.DocComment.SpacingBeforeTags` sniff code [changed](https://github.com/squizlabs/PHP_CodeSniffer/pull/1990), so even with our current excludes, it doesn't allow one-line annotations (which we use):
```
class Example
{
    /** @var string */
    private $userId;
    /** @var string[] */
    private $itemIds = [];
}
```
This will with PHP_CS 3.3.0 [cause](https://travis-ci.org/lmc-eu/matej-client-php/jobs/389033616#L1237) an error "There must be exactly one blank line before the tags in a doc comment".

This PR adds this code to other excludes of DocCommentSniff we already have in order to allow  short annotations are do not considered them codestyle violation.