### PR TITLE
Order covers annotation of PHPUnit tests

### DIFF
--- a/easy-coding-standard.yaml
+++ b/easy-coding-standard.yaml
@@ -147,6 +147,8 @@ services:
     # Use expectedException*() methods instead of @expectedException* annotation (both following fixers must be applied to do so)
     PhpCsFixer\Fixer\PhpUnit\PhpUnitNoExpectationAnnotationFixer: ~
     PhpCsFixer\Fixer\PhpUnit\PhpUnitExpectationFixer: ~
+    # Order `@covers` annotation of PHPUnit tests
+    PhpCsFixer\Fixer\PhpUnit\PhpUnitOrderedCoversFixer: ~
     # Visibility of setUp() and tearDown() method should be kept protected
     PhpCsFixer\Fixer\PhpUnit\PhpUnitSetUpTearDownVisibilityFixer: ~
     PhpCsFixer\Fixer\ReturnNotation\NoUselessReturnFixer: ~


### PR DESCRIPTION
This does not affect you if you don't use [`@covers`](https://phpunit.readthedocs.io/en/7.1/annotations.html#covers) annotation on PHPUnit tests.

But if you do (and you cover multiple classes, what is common case for integration tests), you should keep it ordered alphabetically by FQCN of covered classes. The reasoning is the same as for ordered use imports: it increases readability by ordering by vendor/packages (ie. namespaces) and minimizes risk of merge conflicts.