### PR TITLE
Update deprecated ClassNameSuffixByParentFixer implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+- Change deprecated implementation of `Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer` to `Symplify\CodingStandard\Sniffs\Naming\ClassNameSuffixByParentSniff`
 
 ## 1.1.1 - 2018-06-07
 - Fix `Generic.Commenting.DocComment.SpacingBeforeTags` being reported on one-line phpDoc annotations (when PHP_Codesniffer 3.3.0+ is used).

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "symplify/easy-coding-standard": "^4.0.2"
+        "symplify/easy-coding-standard": "^4.5.1"
     },
     "require-dev": {
         "j13k/yaml-lint": "^1.1",

--- a/easy-coding-standard.yaml
+++ b/easy-coding-standard.yaml
@@ -179,8 +179,10 @@ services:
 
     SlevomatCodingStandard\Sniffs\Exceptions\ReferenceThrowableOnlySniff: ~
 
-    Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer:
-        parent_types_to_suffixes:
+    Symplify\CodingStandard\Fixer\Naming\MagicMethodsNamingFixer: ~
+    Symplify\CodingStandard\Sniffs\Naming\AbstractClassNameSniff: ~
+    Symplify\CodingStandard\Sniffs\Naming\ClassNameSuffixByParentSniff:
+        defaultParentClassToSuffixMap:
             '*Command': 'Command'
             '*Controller': 'Controller'
             '*Repository': 'Repository'
@@ -191,8 +193,6 @@ services:
             '*Sniff': 'Sniff'
             '*Exception': 'Exception'
             '*Handler': 'Handler'
-    Symplify\CodingStandard\Fixer\Naming\MagicMethodsNamingFixer: ~
-    Symplify\CodingStandard\Sniffs\Naming\AbstractClassNameSniff: ~
     Symplify\CodingStandard\Sniffs\Naming\InterfaceNameSniff: ~
     Symplify\CodingStandard\Sniffs\Naming\TraitNameSniff: ~
 


### PR DESCRIPTION
`Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer` was deprecated since https://github.com/Symplify/Symplify/pull/957/files and it was replaced by `Symplify\CodingStandard\Sniffs\Naming\ClassNameSuffixByParentSniff`

New implementation has most of common class name suffixes defined as defaults, so it is not explicitelly needed.

Defaults are:
```php
public $defaultParentClassToSuffixMap = [
        'Command',
        'Controller',
        'Repository',
        'Presenter',
        'Request',
        'Response',
        'EventSubscriberInterface',
        'FixerInterface',
        'Sniff',
        'Exception',
        'Handler',
];
```