### PR TITLE
Replace deprecated magic method fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+- Replace deprecated `Symplify\CodingStandard\Fixer\Naming\MagicMethodsNamingFixer` with `PhpCsFixer\Fixer\Casing\MagicMethodCasingFixer`.
 
 ## 1.1.2 - 2018-07-19
 - Change deprecated implementation of `Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer` to `Symplify\CodingStandard\Sniffs\Naming\ClassNameSuffixByParentSniff`

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "symplify/easy-coding-standard": "^4.5.1"
+        "symplify/easy-coding-standard": "^4.7.0"
     },
     "require-dev": {
         "j13k/yaml-lint": "^1.1",

--- a/easy-coding-standard.yaml
+++ b/easy-coding-standard.yaml
@@ -87,6 +87,7 @@ services:
     PhpCsFixer\Fixer\Basic\BracesFixer:
         allow_single_line_closure: true
     PhpCsFixer\Fixer\Basic\Psr4Fixer: ~
+    PhpCsFixer\Fixer\Casing\MagicMethodCasingFixer: ~
     PhpCsFixer\Fixer\Casing\NativeFunctionCasingFixer: ~
     PhpCsFixer\Fixer\CastNotation\CastSpacesFixer: ~
     PhpCsFixer\Fixer\CastNotation\LowercaseCastFixer: ~
@@ -179,7 +180,6 @@ services:
 
     SlevomatCodingStandard\Sniffs\Exceptions\ReferenceThrowableOnlySniff: ~
 
-    Symplify\CodingStandard\Fixer\Naming\MagicMethodsNamingFixer: ~
     Symplify\CodingStandard\Sniffs\Naming\AbstractClassNameSniff: ~
     Symplify\CodingStandard\Sniffs\Naming\ClassNameSuffixByParentSniff:
         defaultParentClassToSuffixMap:


### PR DESCRIPTION
`Symplify\CodingStandard\Fixer\Naming\MagicMethodsNamingFixer` was deprecated in latest ECS, because php-cs-fixer 2.13 now cointains fixer doing the same (`PhpCsFixer\Fixer\Casing\MagicMethodCasingFixer`)