### PR TITLE
Add new fixers from php-cs-fixer 2.12+

### DIFF
--- a/easy-coding-standard.yaml
+++ b/easy-coding-standard.yaml
@@ -77,6 +77,8 @@ services:
     PhpCsFixer\Fixer\Alias\MbStrFunctionsFixer: ~
     PhpCsFixer\Fixer\Alias\NoAliasFunctionsFixer: ~
     PhpCsFixer\Fixer\Alias\RandomApiMigrationFixer: ~
+    # Cast shall be used, not `settype()`
+    PhpCsFixer\Fixer\Alias\SetTypeToCastFixer: ~
     PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer:
         syntax: short
     PhpCsFixer\Fixer\ArrayNotation\NormalizeIndexBraceFixer: ~
@@ -128,6 +130,8 @@ services:
     PhpCsFixer\Fixer\Operator\UnaryOperatorSpacesFixer: ~
     PhpCsFixer\Fixer\Phpdoc\NoBlankLinesAfterPhpdocFixer: ~
     PhpCsFixer\Fixer\Phpdoc\NoEmptyPhpdocFixer: ~
+    # Removes `@param` and `@return` tags that don't provide any useful information
+    PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer: ~
     PhpCsFixer\Fixer\Phpdoc\PhpdocAddMissingParamAnnotationFixer: ~
     PhpCsFixer\Fixer\Phpdoc\PhpdocIndentFixer: ~
     PhpCsFixer\Fixer\Phpdoc\PhpdocNoAccessFixer: ~
@@ -151,6 +155,9 @@ services:
     PhpCsFixer\Fixer\PhpUnit\PhpUnitOrderedCoversFixer: ~
     # Visibility of setUp() and tearDown() method should be kept protected
     PhpCsFixer\Fixer\PhpUnit\PhpUnitSetUpTearDownVisibilityFixer: ~
+    # Calls to `PHPUnit\Framework\TestCase` static methods must all be of the same type (`$this->...`)
+    PhpCsFixer\Fixer\PhpUnit\PhpUnitTestCaseStaticMethodCallsFixer:
+        call_type: 'this'
     PhpCsFixer\Fixer\ReturnNotation\NoUselessReturnFixer: ~
     PhpCsFixer\Fixer\Semicolon\NoEmptyStatementFixer: ~
     PhpCsFixer\Fixer\Semicolon\NoSinglelineWhitespaceBeforeSemicolonsFixer: ~


### PR DESCRIPTION
This adds some new fixers, introduced in php-cs-fixer 2.12 and 2.13.

### `Alias\SetTypeToCastFixer`
Cast shall be used, not `settype()` - what we already everywhere do.

### `PhpUnit\PhpUnitTestCaseStaticMethodCallsFixer`
This unifies usage of PHPUnit's assertion methods (`$this->assert...()` instead of `static::assert...()` or `self::assert...()`). 

I don't know about any LMC project which doesn't follow this rule. And if there is some, this could simply be overwritten on project-level and changed to a different call type or completely disabled.

### `Phpdoc\NoSuperfluousPhpdocTagsFixer`

This is the most interesting one. It removes phpdocs, which do not add any additional information on top of what is already known from method typehints and return type.

For example:
```diff
-    /**
-     * @param string $foo
-     * @return string
-     */
     public function method(string $foo): string
     {
         return '';
     }
```

However if there is any additional information (like comment or array content type), the phpDoc is kept.

```php
    /**
     * @param string $foo Parameter description
     * @return string[]
     */
    public function method(string $foo): array
    {
        return [];
    }
```
