### PR TITLE
Bump ECS dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "symplify/easy-coding-standard": "^4.7.0"
+        "symplify/easy-coding-standard": "^5.2.0"
     },
     "require-dev": {
         "j13k/yaml-lint": "^1.1",


### PR DESCRIPTION
See https://github.com/Symplify/Symplify/blob/master/CHANGELOG.md#v500---2018-09-15 - no change, just requires Symfony `^3.4|^4.1` instead of `^3.4|^4.0`.