### PR TITLE
Add new rules from PHP-CS-Fixer 2.14 and 2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+- Require EasyCodingStandard 5+.
+- Add new fixers from PHP-CS-Fixer 2.14 and 2.13:
+    - `CombineNestedDirnameFixer` - replace multiple nested calls of `dirname` by only one call with second `$level` parameter.
+    - `FopenFlagOrderFixer` - order the flags in `fopen` calls, `b` and `t` must be last.
+    - `FopenFlagsFixer` - the flags in `fopen` calls must contain `b` and must omit `t`.
+    - `ImplodeCallFixer` - function `implode` must be called with 2 arguments in the documented order.
+    - `PhpdocVarAnnotationCorrectOrderFixer` - `@var` and `@type` annotations must have type and name in the correct order
 
 ## 1.2.0 - 2018-09-20
 - Replace deprecated `Symplify\CodingStandard\Fixer\Naming\MagicMethodsNamingFixer` with `PhpCsFixer\Fixer\Casing\MagicMethodCasingFixer`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     - `FopenFlagsFixer` - the flags in `fopen` calls must contain `b` and must omit `t`.
     - `ImplodeCallFixer` - function `implode` must be called with 2 arguments in the documented order.
     - `PhpdocVarAnnotationCorrectOrderFixer` - `@var` and `@type` annotations must have type and name in the correct order
+- Keep `@mixed` annotations preserved when explicitly declared.
 
 ## 1.2.0 - 2018-09-20
 - Replace deprecated `Symplify\CodingStandard\Fixer\Naming\MagicMethodsNamingFixer` with `PhpCsFixer\Fixer\Casing\MagicMethodCasingFixer`.

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "symplify/easy-coding-standard": "^5.2.0"
+        "symplify/easy-coding-standard": "^5.3.0"
     },
     "require-dev": {
         "j13k/yaml-lint": "^1.1",

--- a/easy-coding-standard.yaml
+++ b/easy-coding-standard.yaml
@@ -141,7 +141,8 @@ services:
     PhpCsFixer\Fixer\Phpdoc\NoBlankLinesAfterPhpdocFixer: ~
     PhpCsFixer\Fixer\Phpdoc\NoEmptyPhpdocFixer: ~
     # Removes `@param` and `@return` tags that don't provide any useful information
-    PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer: ~
+    PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer:
+        allow_mixed: true # allow `@mixed` annotations to be preserved
     PhpCsFixer\Fixer\Phpdoc\PhpdocAddMissingParamAnnotationFixer: ~
     PhpCsFixer\Fixer\Phpdoc\PhpdocIndentFixer: ~
     PhpCsFixer\Fixer\Phpdoc\PhpdocNoAccessFixer: ~

--- a/easy-coding-standard.yaml
+++ b/easy-coding-standard.yaml
@@ -106,7 +106,16 @@ services:
         equal: false
         identical: false
         less_and_greater: false
+    # Replace multiple nested calls of `dirname` by only one call with second `$level` parameter.
+    PhpCsFixer\Fixer\FunctionNotation\CombineNestedDirnameFixer: ~
+    # Order the flags in `fopen` calls, `b` and `t` must be last.
+    PhpCsFixer\Fixer\FunctionNotation\FopenFlagOrderFixer: ~
+    # The flags in `fopen` calls must contain `b` and must omit `t`.
+    PhpCsFixer\Fixer\FunctionNotation\FopenFlagsFixer: ~
+    # Add missing space between function's argument and its typehint.
     PhpCsFixer\Fixer\FunctionNotation\FunctionTypehintSpaceFixer: ~
+    # Function `implode` must be called with 2 arguments in the documented order.
+    PhpCsFixer\Fixer\FunctionNotation\ImplodeCallFixer: ~
     PhpCsFixer\Fixer\FunctionNotation\NoUnreachableDefaultArgumentValueFixer: ~
     PhpCsFixer\Fixer\FunctionNotation\ReturnTypeDeclarationFixer: ~
     PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer: ~
@@ -144,6 +153,8 @@ services:
     PhpCsFixer\Fixer\Phpdoc\PhpdocSingleLineVarSpacingFixer: ~
     PhpCsFixer\Fixer\Phpdoc\PhpdocTrimFixer: ~
     PhpCsFixer\Fixer\Phpdoc\PhpdocTypesFixer: ~
+    # `@var` and `@type` annotations must have type and name in the correct order
+    PhpCsFixer\Fixer\Phpdoc\PhpdocVarAnnotationCorrectOrderFixer: ~
     PhpCsFixer\Fixer\PhpTag\FullOpeningTagFixer: ~
     PhpCsFixer\Fixer\PhpUnit\PhpUnitConstructFixer: ~
     PhpCsFixer\Fixer\PhpUnit\PhpUnitDedicateAssertFixer: ~


### PR DESCRIPTION
Bunch of new usable fixers introduced in [latest versions](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/2.14/CHANGELOG.md) of php-cs-fixer.

Nothing revolutionary IMO - just a fixers for long-established best practices.

Also new configuration to keep `@mixed` annotations preserved was added (which was added to php-cs-fixer by @MortalFlesh :tada: ). This is handy eg. for those using phpstan strict rules.