### PR TITLE
Fix of Travis build failure caused by the last phpstan update

### DIFF
--- a/src/Fixer/SpecifyArgSeparatorFixer.php
+++ b/src/Fixer/SpecifyArgSeparatorFixer.php
@@ -31,6 +31,9 @@ class SpecifyArgSeparatorFixer implements DefinedFixerInterface
         );
     }
 
+    /**
+     * @param Tokens<Token> $tokens
+     */
     public function isCandidate(Tokens $tokens): bool
     {
         return $tokens->isTokenKindFound(T_STRING);
@@ -41,6 +44,9 @@ class SpecifyArgSeparatorFixer implements DefinedFixerInterface
         return true;
     }
 
+    /**
+     * @param Tokens<Token> $tokens
+     */
     public function fix(\SplFileInfo $file, Tokens $tokens): void
     {
         foreach ($tokens as $index => $token) {
@@ -70,6 +76,9 @@ class SpecifyArgSeparatorFixer implements DefinedFixerInterface
         return true;
     }
 
+    /**
+     * @param Tokens<Token> $tokens
+     */
     private function fixFunction(Tokens $tokens, int $functionIndex): void
     {
         $openParenthesisIndex = $tokens->getNextTokenOfKind($functionIndex, ['(']);
@@ -118,6 +127,8 @@ class SpecifyArgSeparatorFixer implements DefinedFixerInterface
 
     /**
      * Detect if this is most probably function call (and not function import or function definition).
+     *
+     * @param Tokens<Token> $tokens
      */
     private function isFunctionCall(Tokens $tokens, int $index): bool
     {
@@ -128,6 +139,9 @@ class SpecifyArgSeparatorFixer implements DefinedFixerInterface
                 || $tokens[$previousIndex]->isGivenKind(T_FUNCTION));
     }
 
+    /**
+     * @param Tokens<Token> $tokens
+     */
     private function getThirdArgumentInfo(
         Tokens $tokens,
         int $openParenthesisIndex,
@@ -142,6 +156,9 @@ class SpecifyArgSeparatorFixer implements DefinedFixerInterface
         return $argumentInfo->getTypeAnalysis();
     }
 
+    /**
+     * @param Tokens<Token> $tokens
+     */
     private function setArgumentValueToAmp(Tokens $tokens, int $argumentStartIndex): void
     {
         $ampToken = new Token([T_STRING, "'&'"]);


### PR DESCRIPTION
The currently used phpstan version includes a new check for iterable types.
If a function argument is iterable, phpstan checks that value type
of its elements is specified in PHPDoc.

Example - if a function accepts array of integers as a parameter,
the corresponding PHPDoc part should change from `array` to `array<int>`.

This commit added compliant PHPDoc to functions with iterable arguments.