### PR TITLE
Add new rules from Symplify and PHP-CS-Fixer 2.15 & 2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Unreleased
 - Drop PHP 7.1 support.
 - Require EasyCodingStandard 7+.
+- `VisibilityRequiredFixer` now check visibility is declared also on class constants.
 
 ## 1.3.0 - 2019-01-23
 - Require EasyCodingStandard 5+.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 - Require EasyCodingStandard 7+.
 - `VisibilityRequiredFixer` now check visibility is declared also on class constants.
 - Add `Symplify\ParamReturnAndVarTagMalformsFixer` - the `@param`, `@return` and `@var` annotations should keep standard format.
+- Add new fixers from PHP-CS-Fixer 2.15 and 2.16:
+    - `NativeFunctionTypeDeclarationCasingFixer` - native type hints for functions should use the correct case.
+    - `SingleTraitInsertPerStatementFixer` - each trait `use` must be done as single statement.
+    - `PhpUnitDedicateAssertInternalTypeFixer` - PHPUnit assertions like `assertIsArray()` should be used over `assertInternalType()` (PHPUnit 7.5+ required).
+    - `PhpUnitMockShortWillReturnFixer` - Use of eg. `->will($this->returnValue(..))` must be replaced by its shorter equivalent such as `->willReturn(...)`.
+- `NoSuperfluousPhpdocTagsFixer` now also removes superfluous `@inheritdoc` tags.
 
 ## 1.3.0 - 2019-01-23
 - Require EasyCodingStandard 5+.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Drop PHP 7.1 support.
 - Require EasyCodingStandard 7+.
 - `VisibilityRequiredFixer` now check visibility is declared also on class constants.
+- Add `Symplify\ParamReturnAndVarTagMalformsFixer` - the `@param`, `@return` and `@var` annotations should keep standard format.
 
 ## 1.3.0 - 2019-01-23
 - Require EasyCodingStandard 5+.

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "symplify/easy-coding-standard": "^7.0.0"
+        "symplify/easy-coding-standard": "^7.2.0"
     },
     "require-dev": {
         "j13k/yaml-lint": "^1.1",

--- a/easy-coding-standard.yaml
+++ b/easy-coding-standard.yaml
@@ -203,8 +203,11 @@ services:
     PhpCsFixer\Fixer\Whitespace\NoWhitespaceInBlankLineFixer: ~
 
     SlevomatCodingStandard\Sniffs\Exceptions\ReferenceThrowableOnlySniff: ~
-
+    # The @param, @return, @var and inline @var annotations should keep standard format
+    Symplify\CodingStandard\Fixer\Commenting\ParamReturnAndVarTagMalformsFixer: ~
+    # Abstract class should have prefix "Abstract"
     Symplify\CodingStandard\Sniffs\Naming\AbstractClassNameSniff: ~
+    # Classes should have suffix by theirs parent class/interface
     Symplify\CodingStandard\Sniffs\Naming\ClassNameSuffixByParentSniff:
         defaultParentClassToSuffixMap:
             '*Command': 'Command'
@@ -217,7 +220,9 @@ services:
             '*Sniff': 'Sniff'
             '*Exception': 'Exception'
             '*Handler': 'Handler'
+    # Interface should have suffix "Interface"
     Symplify\CodingStandard\Sniffs\Naming\InterfaceNameSniff: ~
+    # Trait should have suffix "Trait"
     Symplify\CodingStandard\Sniffs\Naming\TraitNameSniff: ~
 
 parameters:

--- a/easy-coding-standard.yaml
+++ b/easy-coding-standard.yaml
@@ -91,6 +91,8 @@ services:
     PhpCsFixer\Fixer\Basic\Psr4Fixer: ~
     PhpCsFixer\Fixer\Casing\MagicMethodCasingFixer: ~
     PhpCsFixer\Fixer\Casing\NativeFunctionCasingFixer: ~
+    # Native type hints for functions should use the correct case
+    PhpCsFixer\Fixer\Casing\NativeFunctionTypeDeclarationCasingFixer:
     PhpCsFixer\Fixer\CastNotation\CastSpacesFixer: ~
     PhpCsFixer\Fixer\CastNotation\LowercaseCastFixer: ~
     PhpCsFixer\Fixer\CastNotation\ShortScalarCastFixer: ~
@@ -99,6 +101,8 @@ services:
             - method
     PhpCsFixer\Fixer\ClassNotation\NoBlankLinesAfterClassOpeningFixer: ~
     PhpCsFixer\Fixer\ClassNotation\SelfAccessorFixer: ~
+    # Each trait `use` must be done as single statement
+    PhpCsFixer\Fixer\ClassNotation\SingleTraitInsertPerStatementFixer: ~
     # Visibility MUST be declared on all properties, methods and class constants
     PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:
         elements:
@@ -148,6 +152,8 @@ services:
     # Removes `@param` and `@return` tags that don't provide any useful information
     PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer:
         allow_mixed: true # allow `@mixed` annotations to be preserved
+        allow_unused_params: false # whether param annotation without actual signature is allowed
+        remove_inheritdoc: true # remove @inheritDoc tags
     PhpCsFixer\Fixer\Phpdoc\PhpdocAddMissingParamAnnotationFixer: ~
     PhpCsFixer\Fixer\Phpdoc\PhpdocIndentFixer: ~
     PhpCsFixer\Fixer\Phpdoc\PhpdocNoAccessFixer: ~
@@ -163,9 +169,14 @@ services:
     PhpCsFixer\Fixer\Phpdoc\PhpdocVarAnnotationCorrectOrderFixer: ~
     PhpCsFixer\Fixer\PhpTag\FullOpeningTagFixer: ~
     PhpCsFixer\Fixer\PhpUnit\PhpUnitConstructFixer: ~
+    # PHPUnit assertions like assertInternalType, assertFileExists, should be used over assertTrue
     PhpCsFixer\Fixer\PhpUnit\PhpUnitDedicateAssertFixer: ~
+    # PHPUnit assertions like assertIsArray should be used over assertInternalType
+    PhpCsFixer\Fixer\PhpUnit\PhpUnitDedicateAssertInternalTypeFixer:
     # Use dedicated helper methods createMock() and createPartialMock() where possible
     PhpCsFixer\Fixer\PhpUnit\PhpUnitMockFixer: ~
+    # Use of eg. ->will($this->returnValue(..)) must be replaced by its shorter equivalent such as ->willReturn(...)
+    PhpCsFixer\Fixer\PhpUnit\PhpUnitMockShortWillReturnFixer: ~
     # Use expectedException*() methods instead of @expectedException* annotation (both following fixers must be applied to do so)
     PhpCsFixer\Fixer\PhpUnit\PhpUnitNoExpectationAnnotationFixer: ~
     PhpCsFixer\Fixer\PhpUnit\PhpUnitExpectationFixer: ~

--- a/easy-coding-standard.yaml
+++ b/easy-coding-standard.yaml
@@ -99,7 +99,12 @@ services:
             - method
     PhpCsFixer\Fixer\ClassNotation\NoBlankLinesAfterClassOpeningFixer: ~
     PhpCsFixer\Fixer\ClassNotation\SelfAccessorFixer: ~
-    PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer: ~
+    # Visibility MUST be declared on all properties, methods and class constants
+    PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:
+        elements:
+            - const
+            - method
+            - property
     PhpCsFixer\Fixer\Comment\NoEmptyCommentFixer: ~
     PhpCsFixer\Fixer\ControlStructure\NoUselessElseFixer: ~
     PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer:


### PR DESCRIPTION
- `VisibilityRequiredFixer` now check visibility is declared also on class constants.
- Add `Symplify\ParamReturnAndVarTagMalformsFixer` - the `@param`, `@return` and `@var` annotations should keep standard format.
- Add new fixers from PHP-CS-Fixer 2.15 and 2.16:
    - `NativeFunctionTypeDeclarationCasingFixer` - native type hints for functions should use the correct case.
    - `SingleTraitInsertPerStatementFixer` - each trait `use` must be done as single statement.
    - `PhpUnitDedicateAssertInternalTypeFixer` - PHPUnit assertions like `assertIsArray()` should be used over `assertInternalType()` **(PHPUnit 7.5+ required)**.
    - `PhpUnitMockShortWillReturnFixer` - Use of eg. `->will($this->returnValue(..))` must be replaced by its shorter equivalent such as `->willReturn(...)`.
- `NoSuperfluousPhpdocTagsFixer` now also removes superfluous `@inheritdoc` tags.