### PR TITLE
Fix regression in latest ECS causing BC break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+- BC: change the way the standard is imported to your `easy-coding-standard.yaml` (change `%vendor_dir%` placeholder directly to name of the vendor directory like `vendor`). See example in [README](https://github.com/lmc-eu/php-coding-standard#usage).
 - Drop PHP 7.1 support.
 - Require EasyCodingStandard 7+.
 - `VisibilityRequiredFixer` now check visibility is declared also on class constants.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ composer require --dev lmc/coding-standard
 
 ```yaml
 imports:
-    - { resource: '%vendor_dir%/lmc/coding-standard/easy-coding-standard.yaml' }
+    - { resource: 'vendor/lmc/coding-standard/easy-coding-standard.yaml' }
 ```
 
 2. Run the check command (for `src/` and `tests/` directories):

--- a/easy-coding-standard.yaml
+++ b/easy-coding-standard.yaml
@@ -1,5 +1,6 @@
 imports:
-    - { resource: '%vendor_dir%/symplify/easy-coding-standard/config/set/psr2.yaml' }
+    - { resource: '../../easy-coding-standard/config/psr2.yml', ignore_errors: not_found }
+    - { resource: 'vendor/symplify/easy-coding-standard/config/psr2.yml', ignore_errors: not_found }
 
 services:
     #  Function http_build_query() should always have specified `$arg_separator` parameter


### PR DESCRIPTION
See https://github.com/symplify/symplify/issues/1796 .

Thus we must release new major version of the coding standard :roll_eyes: .

Also everyone would need to do this in their `easy-coding-standard.yaml`:

```diff
imports:
-    - { resource: '%vendor_dir%/lmc/coding-standard/easy-coding-standard.yaml' }
+    - { resource: 'vendor/lmc/coding-standard/easy-coding-standard.yaml' }
```
