### PR TITLE
Fix PSR-2 rules not being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Unreleased
 - Fix PSR-2 checks to be used again (they were unintentionally not loaded since coding-standard version 2.0.0).
+- Lock dependency of `symplify/coding-standard` to <7.2.20 to avoid deprecation errors.
 
 ## 2.0.2 - 2020-04-23
 - Increase required version of symplify/easy-coding-standard to ^7.2.3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+- Fix PSR-2 checks to be used again (they were unintentionally not loaded since coding-standard version 2.0.0).
 
 ## 2.0.2 - 2020-04-23
 - Increase required version of symplify/easy-coding-standard to ^7.2.3.

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "php": "^7.2",
         "symplify/easy-coding-standard": "^7.2.3",
+        "symplify/coding-standard": "<7.2.20",
         "friendsofphp/php-cs-fixer": "^2.16.3"
     },
     "require-dev": {

--- a/easy-coding-standard.yaml
+++ b/easy-coding-standard.yaml
@@ -1,6 +1,6 @@
 imports:
-    - { resource: '../../easy-coding-standard/config/psr2.yml', ignore_errors: not_found }
-    - { resource: 'vendor/symplify/easy-coding-standard/config/psr2.yml', ignore_errors: not_found }
+    - { resource: '../../easy-coding-standard/config/set/psr2.yaml', ignore_errors: not_found }
+    - { resource: 'vendor/symplify/easy-coding-standard/config/set/psr2.yaml', ignore_errors: not_found }
 
 services:
     #  Function http_build_query() should always have specified `$arg_separator` parameter


### PR DESCRIPTION
Since version 2.0, due to renaming of psr2 sets in ECS, these are not loaded and not applied.

Also lock lock symplify/coding-standard dependency (#39).