### PR TITLE
Lock symfony/dependency-injection version to avoid fatal errors [v2.1 branch]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "php": "^7.2",
         "friendsofphp/php-cs-fixer": "^2.16.3",
+        "symfony/dependency-injection": "<5.2.2",
         "symplify/auto-bind-parameter": "<7.2.20",
         "symplify/autowire-array-parameter": "<7.2.20",
         "symplify/coding-standard": "<7.2.20",


### PR DESCRIPTION
New symfony causes symplify/easy-coding-standard/src/Yaml/CheckerServiceParametersShifter to crash.

This is just a quick workaround for the 2.1 branch. We will se if this need some changes in the main branch.