### PR TITLE
Lock symfony dependency also for <4.4.19 [v2.1 branch]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+- Lock `symfony/dependency-injection` also to `<4.4.19` (to extend the workaround from 2.1.1).
 
 ## 2.1.1 - 2021-01-27
 - Lock `symfony/dependency-injection` version to `<5.2.2` to avoid fatal errors.

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.2",
         "friendsofphp/php-cs-fixer": "^2.16.3",
-        "symfony/dependency-injection": "<5.2.2",
+        "symfony/dependency-injection": "<4.4.19 || >=5.0.0 <5.2.2",
         "symplify/auto-bind-parameter": "<7.2.20",
         "symplify/autowire-array-parameter": "<7.2.20",
         "symplify/coding-standard": "<7.2.20",


### PR DESCRIPTION
This extends workaround for 2.1 branch, made in https://github.com/lmc-eu/php-coding-standard/pull/53 . In main branch, this will be resolved by upgrading to latest ECS.

For the record, this is caused by an issue in ECS: https://github.com/symplify/symplify/issues/2872, https://github.com/symplify/symplify/issues/2873