### PR TITLE
Allow PHP 8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.3', '7.4']
+        php-version: ['7.3', '7.4', '8.0']
         dependencies: ['']
         include:
           - { php-version: '7.3', dependencies: '--prefer-lowest --prefer-stable' }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
         "friendsofphp/php-cs-fixer": "^2.16.3",
         "slevomat/coding-standard": "^6.4.1",
         "symplify/easy-coding-standard": "^9.0.50"


### PR DESCRIPTION
Php-cs-fixer [already allows PHP 8](https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4702) (though not all PHP 8 features are supported).

After #56 is merged, we can allow PHP 8 as well.