### PR TITLE
Workaround for ecs issue caused by PHP_CodeSniffer & php-cs-fixer conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+- Lock `friendsofphp/php-cs-fixer` dependency to <2.18.6 until [symplify#3130](https://github.com/symplify/symplify/issues/3130) is resolved.
 
 ## 3.0.0 - 2021-03-02
 - **[BC break]** Change YAML config to PHP. See [UPGRADE-3.0.md](UPGRADE-3.0.md) for step-by-step upgrade howto.

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "friendsofphp/php-cs-fixer": "^2.16.3",
+        "friendsofphp/php-cs-fixer": "^2.16.3 <v2.18.6",
         "slevomat/coding-standard": "^6.4.1",
         "symplify/easy-coding-standard": "^9.0.50"
     },


### PR DESCRIPTION
See https://github.com/symplify/symplify/issues/3130 and especially https://github.com/symplify/symplify/issues/3130#issuecomment-823192571

As a temporary workaround lets lock php-cs-fixer version...

BTW this IMHO affect also `lmc/coding-standard` 2.x, so this may need to be back-ported there to `2.1` branch.