### PR TITLE
Use PhpUnitExpectationFixer only on PHP 8+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+- `PhpUnitExpectationFixer` is used only on PHP 8.0+ See [symplify#3130](https://github.com/symplify/symplify/issues/3130).
 
 ## 3.0.0 - 2021-03-02
 - **[BC break]** Change YAML config to PHP. See [UPGRADE-3.0.md](UPGRADE-3.0.md) for step-by-step upgrade howto.

--- a/ecs.php
+++ b/ecs.php
@@ -444,8 +444,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         $services->set(PhpUnitMockShortWillReturnFixer::class);
         // Use expectedException*() methods instead of @expectedException* annotation (both following fixers must be applied to do so)
         $services->set(PhpUnitNoExpectationAnnotationFixer::class);
-        // Usages of ->setExpectedException* methods MUST be replaced by ->expectException* methods
-        $services->set(PhpUnitExpectationFixer::class);
+
+        // Following check fails on PHP <8.0. See https://github.com/symplify/symplify/issues/3130
+        if (PHP_VERSION_ID >= 80000) {
+            // Usages of ->setExpectedException* methods MUST be replaced by ->expectException* methods
+            $services->set(PhpUnitExpectationFixer::class);
+        }
+
         // Visibility of setUp() and tearDown() method should be kept protected
         $services->set(PhpUnitSetUpTearDownVisibilityFixer::class);
         // Calls to `PHPUnit\Framework\TestCase` static methods must all be of the same type (`$this->...`)


### PR DESCRIPTION
This is a bit different workaround for https://github.com/symplify/symplify/issues/3130 - as it seems the root issue probably won't get fixed. On PHP <8 the coding standard will degrade gracefully - everything else will work. 

This will not have an impact at all if one already run coding standard checks on PHP 8.0+ (at least on CI server). Which is a good idea anyway.

Replaces #63 .

Related issue:
```sh
In FixerFileProcessor.php line 160:
                                                                                                                                                            
  Fixing of "...Test.php" file by "PhpCsFixer\Fixer\PhpUnit\PhpUnitExpectationFixer" failed: Id must be an int, got "string". in file /(..)./vendor/friendsofphp/php-cs-fixer/src/Tokenizer/Token.php on line 60                                                                
                                                                                                                                                            

In Token.php line 60:
                                    
  Id must be an int, got "string".  
```