### PR TITLE
Workaround for PhpUnitExpectationFixer issue [2.1 branch]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
+## 2.1.3 - 2021-04-21
+- Lock `friendsofphp/php-cs-fixer` dependency to `<2.18.6` because of [symplify#3130](https://github.com/symplify/symplify/issues/3130).
+
 ## 2.1.2 - 2021-02-01
 - Lock `symfony/dependency-injection` also to `<4.4.19` (to extend the workaround from 2.1.1).
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "friendsofphp/php-cs-fixer": "^2.16.3",
+        "friendsofphp/php-cs-fixer": "^2.16.3 <2.18.6",
         "symfony/dependency-injection": "<4.4.19 || >=5.0.0 <5.2.2",
         "symplify/auto-bind-parameter": "<7.2.20",
         "symplify/autowire-array-parameter": "<7.2.20",


### PR DESCRIPTION
Workaround for https://github.com/symplify/symplify/issues/3130 also for 2.1 branch by locking the dependency.

For main branch we have #64 , which is a more long-term solution.