### PR TITLE
Fix SpecifyArgSeparatorFixer incompatible with php-cs-fixer 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+- Fix SpecifyArgSeparatorFixer not compatible with php-cs-fixer 3.0.
 
 ## 3.1.0 - 2021-05-13
 - Use php-cs-fixer 3.0.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,8 +7,6 @@ parameters:
         - vendor/symplify/easy-coding-standard/vendor/squizlabs/php_codesniffer/autoload.php
         - vendor/symplify/easy-coding-standard/vendor/squizlabs/php_codesniffer/src/Util/Tokens.php
     ignoreErrors:
-        - message: '#Parameter \#(2|3) \$(argumentStart|argumentEnd) of method PhpCsFixer\\Tokenizer\\Analyzer\\ArgumentsAnalyzer::getArgumentInfo\(\) expects int#'
-          path: %currentWorkingDirectory%/src/Fixer/SpecifyArgSeparatorFixer.php
         - message: '#Parameter \#1 \$code of static method PhpCsFixer\\Tokenizer\\Tokens::fromCode\(\) expects string, string\|false given#'
           path: %currentWorkingDirectory%/tests/Fixer/SpecifyArgSeparatorFixerTest.php
         - message: '#Parameter \#1 \$filename of function file_get_contents expects string, string\|false given.#'

--- a/tests/Fixer/Fixtures/Correct.php.inc
+++ b/tests/Fixer/Fixtures/Correct.php.inc
@@ -8,6 +8,10 @@ class Correct
     {
         $queryString1 = http_build_query(['foo' => 'bar'], null, '&');
 
+        $queryString1WithMultipleWhitespaces = http_build_query(['foo' => 'bar'], null,   '&');
+
+        $queryString1WithWhitespacesAndComments = http_build_query(['foo' => 'bar'], null, /* comment */  '&' /* x */);
+
         $queryString1WithComment = http_build_query(['foo' => 'bar'], /* Comment, with commas, */ null ,  '&');
 
         $queryString1WithObject = http_build_query((object) ['foo' => 'bar'], null, '&');


### PR DESCRIPTION
Obviously the `@internal` method `PhpCsFixer\Tokenizer\Analyzer\ArgumentsAnalyzer::getArgumentInfo()` [changed its behavior](https://github.com/lmc-eu/php-coding-standard/runs/2616471377?check_suite_focus=true#step:5:13), so it needs to be reimplemented on our side.

