### PR TITLE
Fix: SpecifyArgSeparatorFixer type error in PHP 7.4+ 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+- Fix SpecifyArgSeparatorFixer type error when adding empty `$numeric_prefix` parameter in PHP 7.4+.
 
 ## 3.2.0 - 2021-05-20
 - Fix SpecifyArgSeparatorFixer not compatible with php-cs-fixer 3.0.

--- a/src/Fixer/SpecifyArgSeparatorFixer.php
+++ b/src/Fixer/SpecifyArgSeparatorFixer.php
@@ -81,7 +81,11 @@ class SpecifyArgSeparatorFixer implements FixerInterface
 
         // When third argument is already present and it is null, override its value.
         if ($argumentCount >= 3) {
-            $thirdArgumentTuple = $this->getThirdArgumentTokenTuple($tokens, $openParenthesisIndex, $closeParenthesisIndex);
+            $thirdArgumentTuple = $this->getThirdArgumentTokenTuple(
+                $tokens,
+                $openParenthesisIndex,
+                $closeParenthesisIndex
+            );
             if ($thirdArgumentTuple === []) {
                 return;
             }
@@ -100,7 +104,7 @@ class SpecifyArgSeparatorFixer implements FixerInterface
         if ($argumentCount === 1) {
             $tokensToInsert[] = new Token(',');
             $tokensToInsert[] = new Token([T_WHITESPACE, ' ']);
-            $tokensToInsert[] = new Token([T_STRING, 'null']);
+            $tokensToInsert[] = new Token([T_STRING, "''"]);
         }
 
         // Add third argument (arg separator): ", '&'"

--- a/tests/Fixer/Fixtures/Correct.php.inc
+++ b/tests/Fixer/Fixtures/Correct.php.inc
@@ -6,20 +6,20 @@ class Correct
 {
     public function assembleQueryString(): void
     {
-        $queryString1 = http_build_query(['foo' => 'bar'], null, '&');
+        $queryString1 = http_build_query(['foo' => 'bar'], '', '&');
 
-        $queryString1WithMultipleWhitespaces = http_build_query(['foo' => 'bar'], null,   '&');
+        $queryString1WithMultipleWhitespaces = http_build_query(['foo' => 'bar'], 'prefix',   '&');
 
-        $queryString1WithWhitespacesAndComments = http_build_query(['foo' => 'bar'], null, /* comment */  '&' /* x */);
+        $queryString1WithWhitespacesAndComments = http_build_query(['foo' => 'bar'], '', /* comment */  '&' /* x */);
 
-        $queryString1WithComment = http_build_query(['foo' => 'bar'], /* Comment, with commas, */ null ,  '&');
+        $queryString1WithComment = http_build_query(['foo' => 'bar'], /* Comment, with commas, */ '' ,  '&');
 
-        $queryString1WithObject = http_build_query((object) ['foo' => 'bar'], null, '&');
+        $queryString1WithObject = http_build_query((object) ['foo' => 'bar'], '', '&');
 
-        $queryString2 = http_build_query(['foo' => 'bar', 'baz' => 'bat'], null, '&');
+        $queryString2 = http_build_query(['foo' => 'bar', 'baz' => 'bat'], '', '&');
 
-        $queryString3 = http_build_query(['foo' => 'bar'], null, '&amp;');
+        $queryString3 = http_build_query(['foo' => 'bar'], '', '&amp;');
 
-        $queryString4 = http_build_query(['foo' => 'bar'], null, ';');
+        $queryString4 = http_build_query(['foo' => 'bar'], '', ';');
     }
 }

--- a/tests/Fixer/Fixtures/Fixed.php.inc
+++ b/tests/Fixer/Fixtures/Fixed.php.inc
@@ -1,23 +1,30 @@
 <?php declare(strict_types=1);
 
-function http_build_query($should, $not, $change): void
-{
-    // this should not be affected
+/**
+ * The function declaration should not be affected
+ */
+function http_build_query(
+    $data, // TODO: array|object in PHP 8.0+
+    string $numeric_prefix = '',
+    ?string $arg_separator = null,
+    int $encoding_type = PHP_QUERY_RFC1738
+): string {
+    return 'foo';
 }
 
 function assembleQueryString(): void
 {
-    $queryString1 = http_build_query(['foo' => 'bar'], null, '&');
+    $queryString1 = http_build_query(['foo' => 'bar'], '', '&');
 
-    $queryString2 = http_build_query(['foo' => 'bar'], 333, '&');
+    $queryString2 = http_build_query(['foo' => 'bar'], '', '&');
 
-    $queryString3 = http_build_query(['foo' => 'bar'], 333, '&');
+    $queryString3 = http_build_query(['foo' => 'bar'], '', '&');
 
-    $queryString4 = http_build_query(['foo' => 'bar'], 333, '&', PHP_QUERY_RFC3986);
+    $queryString4 = http_build_query(['foo' => 'bar'], '', '&', PHP_QUERY_RFC3986);
 
-    $queryString5 = http_build_query(['foo' => 'bar'], null, '&', PHP_QUERY_RFC3986);
+    $queryString5 = http_build_query(['foo' => 'bar'], 'prefix', '&', PHP_QUERY_RFC3986);
 
-    $queryString6 = http_build_query(['foo' => 'bar', 'baz' => 'ban'], null, '&', PHP_QUERY_RFC3986);
+    $queryString6 = http_build_query(['foo' => 'bar', 'baz' => 'ban'], '', '&', PHP_QUERY_RFC3986);
 
-    $queryString6 = http_build_query((object) ['foo' => 'bar', 'baz' => 'ban'], null, '&', PHP_QUERY_RFC3986);
+    $queryString7 = http_build_query((object) ['foo' => 'bar', 'baz' => 'ban'], '', '&', PHP_QUERY_RFC3986);
 }

--- a/tests/Fixer/Fixtures/Wrong.php.inc
+++ b/tests/Fixer/Fixtures/Wrong.php.inc
@@ -1,23 +1,30 @@
 <?php declare(strict_types=1);
 
-function http_build_query($should, $not, $change): void
-{
-    // this should not be affected
+/**
+ * The function declaration should not be affected
+ */
+function http_build_query(
+    $data, // TODO: array|object in PHP 8.0+
+    string $numeric_prefix = '',
+    ?string $arg_separator = null,
+    int $encoding_type = PHP_QUERY_RFC1738
+): string {
+    return 'foo';
 }
 
 function assembleQueryString(): void
 {
     $queryString1 = http_build_query(['foo' => 'bar']);
 
-    $queryString2 = http_build_query(['foo' => 'bar'], 333);
+    $queryString2 = http_build_query(['foo' => 'bar'], '');
 
-    $queryString3 = http_build_query(['foo' => 'bar'], 333, null);
+    $queryString3 = http_build_query(['foo' => 'bar'], '', null);
 
-    $queryString4 = http_build_query(['foo' => 'bar'], 333, null, PHP_QUERY_RFC3986);
+    $queryString4 = http_build_query(['foo' => 'bar'], '', null, PHP_QUERY_RFC3986);
 
-    $queryString5 = http_build_query(['foo' => 'bar'], null, null, PHP_QUERY_RFC3986);
+    $queryString5 = http_build_query(['foo' => 'bar'], 'prefix', null, PHP_QUERY_RFC3986);
 
-    $queryString6 = http_build_query(['foo' => 'bar', 'baz' => 'ban'], null, null, PHP_QUERY_RFC3986);
+    $queryString6 = http_build_query(['foo' => 'bar', 'baz' => 'ban'], '', null, PHP_QUERY_RFC3986);
 
-    $queryString6 = http_build_query((object) ['foo' => 'bar', 'baz' => 'ban'], null, null, PHP_QUERY_RFC3986);
+    $queryString7 = http_build_query((object) ['foo' => 'bar', 'baz' => 'ban'], '', null, PHP_QUERY_RFC3986);
 }


### PR DESCRIPTION
Fixes #72 .

@janbarasek Could you please try it on your codebase?

In require-dev of composer.json:

```json
    "lmc/coding-standard": "dev-fix/type-error",
```