### PR TITLE
Lock ECS version because of BC breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+- Lock `symplify/easy-coding-standard` to <10.2.4 because of backward incompatibilities introduced in its bugfix releases.
 
 ## 3.3.0 - 2022-04-21
 - Update to symplify/easy-coding-standard ^10.0

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "nette/utils": "^3.2",
         "slevomat/coding-standard": "^6.4.1 || ^7.0",
         "squizlabs/php_codesniffer": "^3.6",
-        "symplify/easy-coding-standard": "^10.0"
+        "symplify/easy-coding-standard": "^10.0 <10.2.4"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.13.2",


### PR DESCRIPTION
New ECS versions are broken for us. So lets temporarily lock the version and see what we can do for the future.

- https://github.com/symplify/symplify/pull/4065
- https://github.com/symplify/symplify/pull/4066
- https://github.com/symplify/symplify/pull/4069