### PR TITLE
Chore: Add basic 'integration' tests to ensure code style is being properly checked

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "nette/utils": "^3.2",
         "slevomat/coding-standard": "^8.0",
         "squizlabs/php_codesniffer": "^3.9",
-        "symplify/easy-coding-standard": "^12.1.4"
+        "symplify/easy-coding-standard": "^12.1.5"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.13.2",

--- a/ecs-internal.php
+++ b/ecs-internal.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types=1);
 
+use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestAnnotationFixer;
 use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
@@ -19,4 +20,9 @@ return ECSConfig::configure()
     ->withConfiguredRule(
         LineLengthFixer::class,
         ['line_length' => 120, 'break_long_lines' => true, 'inline_short_lines' => false],
+    )
+    ->withSkip(
+        [
+            ForbiddenFunctionsSniff::class => ['tests/Integration/CodingStandardTest.php'],
+        ],
     );

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,8 @@ parameters:
         - vendor/symplify/easy-coding-standard/vendor/squizlabs/php_codesniffer/autoload.php
         - vendor/symplify/easy-coding-standard/vendor/squizlabs/php_codesniffer/src/Util/Tokens.php
     ignoreErrors:
-        - message: '#Parameter \#1 \$code of static method PhpCsFixer\\Tokenizer\\Tokens::fromCode\(\) expects string, string\|false given#'
-          path: %currentWorkingDirectory%/tests/Fixer/SpecifyArgSeparatorFixerTest.php
+        - path: %currentWorkingDirectory%/tests/Fixer/SpecifyArgSeparatorFixerTest.php
+          message: '#Parameter \#1 \$code of static method PhpCsFixer\\Tokenizer\\Tokens::fromCode\(\) expects string, string\|false given#'
+        - path: %currentWorkingDirectory%/tests/Integration/CodingStandardTest.php
+          message: '#Parameter \#2 \$actualString of method PHPUnit\\Framework\\Assert::assertStringEqualsFile\(\) expects string, string\|false given#'
     checkMissingIterableValueType: false

--- a/tests/Integration/CodingStandardTest.php
+++ b/tests/Integration/CodingStandardTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\CodingStandard\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversNothing
+ */
+class CodingStandardTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider provideFilesToFix
+     */
+    public function shouldFixFile(string $wrongFile, string $correctFile): void
+    {
+        // copy wrongFile to a new temporary file
+        $fixtureFile = tempnam(sys_get_temp_dir(), 'ecs-test');
+        if ($fixtureFile === false) {
+            $this->fail('Could not create temporary file');
+        }
+        copy($wrongFile, $fixtureFile);
+
+        shell_exec(
+            __DIR__ . '/../../vendor/bin/ecs check --no-progress-bar --no-ansi --no-interaction --fix ' . $fixtureFile,
+        );
+
+        $this->assertStringEqualsFile($correctFile, file_get_contents($fixtureFile));
+        unlink($fixtureFile);
+    }
+
+    public function provideFilesToFix(): array
+    {
+        return [
+            'Basic' => [__DIR__ . '/Fixtures/Basic.wrong.php.inc', __DIR__ . '/Fixtures/Basic.correct.php.inc'],
+            'NewPhpFeatures' => [
+                __DIR__ . '/Fixtures/NewPhpFeatures.wrong.php.inc',
+                __DIR__ . '/Fixtures/NewPhpFeatures.correct.php.inc',
+            ],
+        ];
+    }
+}

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+class Basic
+{
+    public const FOO = 'foo'; // ClassAttributesSeparationFixer
+
+    public function isEqual($a, $b) // VisibilityRequiredFixer
+    {
+        // TrimArraySpacesFixer
+        $fooBar = ['a', 'b'];
+        // MbStrFunctionsFixer
+        $bazLength = mb_strlen('baz');
+        // LambdaNotUsedImportFixer
+        $lambdaWithUnusedImport = function () { return 'foo'; };
+        // NoUselessSprintfFixer
+        $uselessSprintf = 'bar';
+        // SingleSpaceAfterConstructFixer
+        if ($a == $b) {
+            return true;
+        }
+
+        return false; // BlankLineBeforeStatementFixer
+    }
+
+    public function fooBar(mixed $foo): mixed
+    {
+        // TernaryToElvisOperatorFixer
+        return ($foo ?: 'not true');
+    }
+}

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+class Basic
+{
+    const FOO = 'foo'; // ClassAttributesSeparationFixer
+    function isEqual($a, $b) // VisibilityRequiredFixer
+    {
+        // TrimArraySpacesFixer
+        $fooBar = [ 'a', 'b'];
+        // MbStrFunctionsFixer
+        $bazLength = strlen('baz');
+        // LambdaNotUsedImportFixer
+        $lambdaWithUnusedImport = function () use ($fooBar) { return 'foo'; };
+        // NoUselessSprintfFixer
+        $uselessSprintf = sprintf('bar');
+        // SingleSpaceAfterConstructFixer
+        if ($a == $b) { return  true; }
+        return false; // BlankLineBeforeStatementFixer
+    }
+
+    public function fooBar(mixed $foo): mixed
+    {
+        // TernaryToElvisOperatorFixer
+        return ($foo ? $foo : 'not true');
+    }
+}

--- a/tests/Integration/Fixtures/NewPhpFeatures.correct.php.inc
+++ b/tests/Integration/Fixtures/NewPhpFeatures.correct.php.inc
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\CodingStandard\Integration\Fixtures;
+
+class NewPhpFeatures
+{
+    public function __construct(private string $someString) // RequireConstructorPropertyPromotionSniff
+    {
+    }
+
+    public function php80features(
+        string|bool $foo, // UnionTypeHintFormatSniff
+        int $bar, // RequireTrailingCommaInDeclarationSniff
+    ): string|bool {
+        $value = mt_rand(
+            0,
+            $bar, // RequireTrailingCommaInCallSniff
+        );
+
+        $dateOrNull = $this->mayReturnDateTimeOrNull();
+        $timestamp = $dateOrNull?->getTimestamp(); // RequireNullSafeObjectOperatorSniff
+
+        return $foo;
+    }
+
+    public function mayReturnDateTimeOrNull(): ?\DateTime
+    {
+        return null;
+    }
+}

--- a/tests/Integration/Fixtures/NewPhpFeatures.wrong.php.inc
+++ b/tests/Integration/Fixtures/NewPhpFeatures.wrong.php.inc
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\CodingStandard\Integration\Fixtures;
+
+class NewPhpFeatures
+{
+    private string $someString;
+
+    public function __construct(string $someString) // RequireConstructorPropertyPromotionSniff
+    {
+        $this->someString = $someString;
+    }
+
+    public function php80features(
+        string | bool $foo, // UnionTypeHintFormatSniff
+        int $bar // RequireTrailingCommaInDeclarationSniff
+    ): string | bool {
+        $value = mt_rand(
+            0,
+            $bar // RequireTrailingCommaInCallSniff
+        );
+
+        $dateOrNull = $this->mayReturnDateTimeOrNull();
+        $timestamp = $dateOrNull !== null ? $dateOrNull->getTimestamp() : null; // RequireNullSafeObjectOperatorSniff
+
+        return $foo;
+    }
+
+    public function mayReturnDateTimeOrNull(): ?\DateTime
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
This tests runs the configuration against provided fixture files and makes sure they are fixed to our expected code style.  
Thanks to this, we will finally have a way how to make sure the configuration works as expected and nothing breaks.

We may also add more fixtures files later.