### PR TITLE
Add new fixers

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,10 @@ return ECSConfig::configure()
         [
             // PHPUnit attributes must be used over their respective PHPDoc-based annotations. (Use with PHPUnit 10+.)
             PhpUnitAttributesFixer::class,
-            // Single-line comments must have proper spacing.
+            // Single-line comments must have proper spacing (one space after `//`).
             SingleLineCommentSpacingFixer::class,
+            // Convert multiline string to heredoc or nowdoc.
+            MultilineStringToHeredocFixer::class,
         ]
     )
     // Enforce line-length to 120 characters.

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -85,6 +85,11 @@ $ vendor/bin/ecs check --ansi src/ tests/ # old
 $ vendor/bin/ecs check --ansi # new
 ```
 
+### 6. Add some optional rules
+On top of default rules included in ecs.php, there are some more opinionated ones you may want to add.
+
+These suggested rules are listed in [README.md](https://github.com/lmc-eu/php-coding-standard?tab=readme-ov-file#add-custom-checks-or-override-default-settings).
+
 ### 5. BE CAREFUL WITH SUGGESTED CHANGES! ⚠️
 
 Some of the new default fixers introduced in php-coding-standard 4.0 and 4.1 suggest changes, which - if not

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": "^8.0",
-        "friendsofphp/php-cs-fixer": "^3.0",
-        "slevomat/coding-standard": "^8.0",
+        "friendsofphp/php-cs-fixer": "^3.47.1",
+        "slevomat/coding-standard": "^8.6",
         "squizlabs/php_codesniffer": "^3.9",
         "symplify/easy-coding-standard": "^12.1.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "friendsofphp/php-cs-fixer": "^3.47.1",
         "slevomat/coding-standard": "^8.6",
         "squizlabs/php_codesniffer": "^3.9",
-        "symplify/easy-coding-standard": "^12.1.5"
+        "symplify/easy-coding-standard": "^12.1.9"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.42.0",

--- a/ecs-internal.php
+++ b/ecs-internal.php
@@ -6,7 +6,7 @@ use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestAnnotationFixer;
 use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 
-/**
+/*
  * Internal rules configuration for the lmc/coding-standard project itself
  */
 return ECSConfig::configure()

--- a/ecs.php
+++ b/ecs.php
@@ -145,6 +145,7 @@ use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
 use PhpCsFixer\Fixer\Strict\StrictParamFixer;
 use PhpCsFixer\Fixer\StringNotation\MultilineStringToHeredocFixer;
+use PhpCsFixer\Fixer\StringNotation\SimpleToComplexStringVariableFixer;
 use PhpCsFixer\Fixer\StringNotation\SingleQuoteFixer;
 use PhpCsFixer\Fixer\Whitespace\ArrayIndentationFixer;
 use PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer;
@@ -408,6 +409,8 @@ return ECSConfig::configure()
             StrictComparisonFixer::class,
             // Convert multiline string to heredoc or nowdoc.
             MultilineStringToHeredocFixer::class,
+            // Converts explicit variables in double-quoted strings from simple to complex format (${ to {$).
+            SimpleToComplexStringVariableFixer::class,
             // Convert double quotes to single quotes for simple strings
             SingleQuoteFixer::class,
             // Each element of an array must be indented exactly once.

--- a/ecs.php
+++ b/ecs.php
@@ -132,6 +132,7 @@ use PhpCsFixer\Fixer\PhpUnit\PhpUnitConstructFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitDedicateAssertFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitDedicateAssertInternalTypeFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitExpectationFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitFqcnAnnotationFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitMockFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitMockShortWillReturnFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitNoExpectationAnnotationFixer;
@@ -391,6 +392,8 @@ return ECSConfig::configure()
             PhpUnitNoExpectationAnnotationFixer::class,
             // Usages of ->setExpectedException* methods MUST be replaced by ->expectException* methods
             PhpUnitExpectationFixer::class,
+            // PHPUnit annotations should be a FQCNs including a root namespace.
+            PhpUnitFqcnAnnotationFixer::class,
             // Visibility of setUp() and tearDown() method should be kept protected
             PhpUnitSetUpTearDownVisibilityFixer::class,
             // There should not be an empty `return` statement at the end of a function

--- a/ecs.php
+++ b/ecs.php
@@ -526,7 +526,6 @@ return ECSConfig::configure()
     ->withConfiguredRule(ConcatSpaceFixer::class, ['spacing' => 'one'])
     // Removes `@param` and `@return` tags that don't provide any useful information
     ->withConfiguredRule(NoSuperfluousPhpdocTagsFixer::class, [
-        'allow_mixed' => true, // allow `@mixed` annotations to be preserved
         'allow_unused_params' => false, // whether param annotation without actual signature is allowed
         'remove_inheritdoc' => true, // remove @inheritDoc tags
     ])

--- a/ecs.php
+++ b/ecs.php
@@ -55,6 +55,7 @@ use PhpCsFixer\Fixer\CastNotation\LowercaseCastFixer;
 use PhpCsFixer\Fixer\CastNotation\ShortScalarCastFixer;
 use PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer;
 use PhpCsFixer\Fixer\ClassNotation\NoBlankLinesAfterClassOpeningFixer;
+use PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer;
 use PhpCsFixer\Fixer\ClassNotation\SelfAccessorFixer;
 use PhpCsFixer\Fixer\ClassNotation\SingleTraitInsertPerStatementFixer;
 use PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer;
@@ -519,6 +520,23 @@ return ECSConfig::configure()
             'use_trait',
         ],
     ])
+    // Elements of classes/interfaces/traits/enums should be in the defined order
+    ->withConfiguredRule(
+        OrderedClassElementsFixer::class,
+        [
+            'order' => [
+                'use_trait',
+                'case', // enum values should be before other elements
+                'constant',
+                'property',
+                'construct',
+                'destruct',
+                'magic',
+                'phpunit', // phpunit special methods like setUp should be before test methods
+                'method',
+            ],
+        ],
+    )
     ->withSkip([
         // We allow empty catch statements (but they must have comment - see EmptyCatchCommentSniff)
         EmptyStatementSniff::class . '.DetectedCatch' => null,

--- a/ecs.php
+++ b/ecs.php
@@ -337,8 +337,6 @@ return ECSConfig::configure()
             PhpdocNoEmptyReturnFixer::class,
             // `@package` and `@subpackage` annotations should be omitted from PHPDoc.
             PhpdocNoPackageFixer::class,
-            // Annotations in PHPDoc should be ordered.
-            PhpdocOrderFixer::class,
             // The type of `@return` annotations of methods returning a reference to itself must the configured one.
             PhpdocReturnSelfReferenceFixer::class,
             // Scalar types should always be written in the same form.
@@ -502,6 +500,8 @@ return ECSConfig::configure()
     ])
     // All items of the given PHPDoc tags must be left-aligned.
     ->withConfiguredRule(PhpdocAlignFixer::class, ['align' => 'left'])
+    // Annotations in PHPDoc should be ordered in defined sequence.
+    ->withConfiguredRule(PhpdocOrderFixer::class, ['order' => ['param', 'return', 'throws']])
     // Order phpdoc tags by value.
     ->withConfiguredRule(PhpdocOrderByValueFixer::class, ['annotations' => ['covers', 'group', 'throws']])
     // Calls to `PHPUnit\Framework\TestCase` static methods must all be of the same type (`$this->...`)

--- a/ecs.php
+++ b/ecs.php
@@ -349,9 +349,9 @@ return ECSConfig::configure()
             TernaryToNullCoalescingFixer::class,
             // Unary operators should be placed adjacent (without a space) to their operands.
             UnaryOperatorSpacesFixer::class,
-
+            // There should not be blank lines between docblock and the documented element.
             NoBlankLinesAfterPhpdocFixer::class,
-
+            // There should not be empty PHPDoc blocks.
             NoEmptyPhpdocFixer::class,
             // PHPDoc should contain `@param` for all params.
             PhpdocAddMissingParamAnnotationFixer::class,
@@ -445,17 +445,8 @@ return ECSConfig::configure()
             // Promote constructor properties
             // For php-cs-fixer implementation @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5956
             RequireConstructorPropertyPromotionSniff::class,
-
-            // switch -> match
-            // @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5894
-
-            // Require \Stringable interface in classes implementing __toString() method
-            // > it may probably be a phpstan rule, more than cs rule - since it needs a class hierarchy to solve this
-            // @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6235
-
             // Multi-line arguments list in function/method call must have a trailing comma
             RequireTrailingCommaInCallSniff::class, // TODO: will be redundant after https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7989 is merged and released
-
             // Use `null-safe` operator `?->` where possible
             RequireNullSafeObjectOperatorSniff::class,
         ],

--- a/ecs.php
+++ b/ecs.php
@@ -133,6 +133,7 @@ use PhpCsFixer\Fixer\PhpUnit\PhpUnitDedicateAssertFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitDedicateAssertInternalTypeFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitExpectationFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitFqcnAnnotationFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitMethodCasingFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitMockFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitMockShortWillReturnFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitNoExpectationAnnotationFixer;
@@ -538,6 +539,8 @@ return ECSConfig::configure()
     ->withConfiguredRule(PhpdocOrderFixer::class, ['order' => ['param', 'return', 'throws']])
     // Order phpdoc tags by value.
     ->withConfiguredRule(PhpdocOrderByValueFixer::class, ['annotations' => ['covers', 'group', 'throws']])
+    // Enforce camel case for PHPUnit test methods.
+    ->withConfiguredRule(PhpUnitMethodCasingFixer::class, ['case' => 'camel_case'])
     // Calls to `PHPUnit\Framework\TestCase` static methods must all be of the same type (`$this->...`)
     ->withConfiguredRule(PhpUnitTestCaseStaticMethodCallsFixer::class, ['call_type' => 'this'])
     // An empty line feed must precede any configured statement

--- a/ecs.php
+++ b/ecs.php
@@ -149,7 +149,6 @@ use SlevomatCodingStandard\Sniffs\Classes\RequireConstructorPropertyPromotionSni
 use SlevomatCodingStandard\Sniffs\ControlStructures\RequireNullSafeObjectOperatorSniff;
 use SlevomatCodingStandard\Sniffs\Exceptions\ReferenceThrowableOnlySniff;
 use SlevomatCodingStandard\Sniffs\Functions\RequireTrailingCommaInCallSniff;
-use SlevomatCodingStandard\Sniffs\Functions\RequireTrailingCommaInDeclarationSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff;
@@ -234,8 +233,6 @@ return ECSConfig::configure()
             SingleLineEmptyBodyFixer::class, // Defined in PER 2.0
             // Values separated by a comma on a single line should not have a trailing comma.
             NoTrailingCommaInSinglelineFixer::class,
-            // Multi-line arrays, arguments list and parameters list must have a trailing comma
-            TrailingCommaInMultilineFixer::class,
             // Arrays should be formatted like function/method arguments
             TrimArraySpacesFixer::class,
             // In array declaration, there MUST be a whitespace after each comma
@@ -422,10 +419,8 @@ return ECSConfig::configure()
             // > it may probably be a phpstan rule, more than cs rule - since it needs a class hierarchy to solve this
             // @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6235
 
-            // Multi-line arguments list in function/method declaration must have a trailing comma
-            RequireTrailingCommaInDeclarationSniff::class,
             // Multi-line arguments list in function/method call must have a trailing comma
-            RequireTrailingCommaInCallSniff::class,
+            RequireTrailingCommaInCallSniff::class, // TODO: will be redundant after https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7989 is merged and released
 
             // Use `null-safe` operator `?->` where possible
             RequireNullSafeObjectOperatorSniff::class,
@@ -551,6 +546,11 @@ return ECSConfig::configure()
     ->withConfiguredRule(
         FunctionDeclarationFixer::class,
         ['closure_fn_spacing' => 'none'], // Defined in PER 2.0
+    )
+    // Multi-line arrays, arguments list and parameters list must have a trailing comma
+    ->withConfiguredRule(
+        TrailingCommaInMultilineFixer::class,
+        ['after_heredoc' => true, 'elements' => ['arguments', 'arrays', 'match', 'parameters']], // Defined in PER 2.0
     )
     ->withSkip([
         // We allow empty catch statements (but they must have comment - see EmptyCatchCommentSniff)

--- a/ecs.php
+++ b/ecs.php
@@ -137,6 +137,7 @@ use PhpCsFixer\Fixer\Semicolon\SpaceAfterSemicolonFixer;
 use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
 use PhpCsFixer\Fixer\Strict\StrictParamFixer;
+use PhpCsFixer\Fixer\StringNotation\MultilineStringToHeredocFixer;
 use PhpCsFixer\Fixer\StringNotation\SingleQuoteFixer;
 use PhpCsFixer\Fixer\Whitespace\ArrayIndentationFixer;
 use PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer;
@@ -386,6 +387,8 @@ return ECSConfig::configure()
             StrictParamFixer::class,
             // Comparisons should be strict, `===` or `!==` must be used for comparisons
             StrictComparisonFixer::class,
+            // Convert multiline string to heredoc or nowdoc.
+            MultilineStringToHeredocFixer::class,
             // Convert double quotes to single quotes for simple strings
             SingleQuoteFixer::class,
             // Each element of an array must be indented exactly once.

--- a/ecs.php
+++ b/ecs.php
@@ -63,6 +63,7 @@ use PhpCsFixer\Fixer\ClassNotation\SingleTraitInsertPerStatementFixer;
 use PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer;
 use PhpCsFixer\Fixer\Comment\NoEmptyCommentFixer;
 use PhpCsFixer\Fixer\Comment\SingleLineCommentSpacingFixer;
+use PhpCsFixer\Fixer\ControlStructure\NoUnneededControlParenthesesFixer;
 use PhpCsFixer\Fixer\ControlStructure\NoUselessElseFixer;
 use PhpCsFixer\Fixer\ControlStructure\SwitchContinueToBreakFixer;
 use PhpCsFixer\Fixer\ControlStructure\TrailingCommaInMultilineFixer;
@@ -565,6 +566,11 @@ return ECSConfig::configure()
     ->withConfiguredRule(
         FunctionDeclarationFixer::class,
         ['closure_fn_spacing' => 'none'], // Defined in PER 2.0
+    )
+    // Removes unneeded parentheses around specified control statements.
+    ->withConfiguredRule(
+        NoUnneededControlParenthesesFixer::class,
+        ['statements' => ['break', 'clone', 'continue', 'echo_print', 'others', 'switch_case', 'yield', 'yield_from']],
     )
     // Multi-line arrays, arguments list and parameters list must have a trailing comma
     ->withConfiguredRule(

--- a/ecs.php
+++ b/ecs.php
@@ -106,6 +106,7 @@ use PhpCsFixer\Fixer\Phpdoc\PhpdocOrderFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocReturnSelfReferenceFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocScalarFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocSingleLineVarSpacingFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocToCommentFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocTrimFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocTypesFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocVarAnnotationCorrectOrderFixer;
@@ -332,6 +333,8 @@ return ECSConfig::configure()
             PhpdocSingleLineVarSpacingFixer::class,
             // PHPDoc should start and end with content
             PhpdocTrimFixer::class,
+            // Docblocks should only be used on structural elements.
+            PhpdocToCommentFixer::class,
             // The correct case must be used for standard PHP types in PHPDoc.
             PhpdocTypesFixer::class,
             // `@var` and `@type` annotations must have type and name in the correct order

--- a/ecs.php
+++ b/ecs.php
@@ -77,6 +77,7 @@ use PhpCsFixer\Fixer\FunctionNotation\LambdaNotUsedImportFixer;
 use PhpCsFixer\Fixer\FunctionNotation\MethodArgumentSpaceFixer;
 use PhpCsFixer\Fixer\FunctionNotation\NoUnreachableDefaultArgumentValueFixer;
 use PhpCsFixer\Fixer\FunctionNotation\NoUselessSprintfFixer;
+use PhpCsFixer\Fixer\FunctionNotation\NullableTypeDeclarationForDefaultNullValueFixer;
 use PhpCsFixer\Fixer\FunctionNotation\PhpdocToParamTypeFixer;
 use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
 use PhpCsFixer\Fixer\FunctionNotation\PhpdocToReturnTypeFixer;
@@ -296,6 +297,8 @@ return ECSConfig::configure()
             NoUnreachableDefaultArgumentValueFixer::class,
             // There must be no `sprintf` calls with only the first argument.
             NoUselessSprintfFixer::class,
+            // Add `?` before single type declarations when parameters have a default null value.
+            NullableTypeDeclarationForDefaultNullValueFixer::class,
             // There must not be a space before colon in return type declarations.
             ReturnTypeDeclarationFixer::class,
             // Add `void` return type to functions with missing or empty return statements.

--- a/ecs.php
+++ b/ecs.php
@@ -46,6 +46,7 @@ use PhpCsFixer\Fixer\ArrayNotation\WhitespaceAfterCommaInArrayFixer;
 use PhpCsFixer\Fixer\Basic\BracesFixer;
 use PhpCsFixer\Fixer\Basic\NoTrailingCommaInSinglelineFixer;
 use PhpCsFixer\Fixer\Basic\PsrAutoloadingFixer;
+use PhpCsFixer\Fixer\Casing\ClassReferenceNameCasingFixer;
 use PhpCsFixer\Fixer\Casing\MagicMethodCasingFixer;
 use PhpCsFixer\Fixer\Casing\NativeFunctionCasingFixer;
 use PhpCsFixer\Fixer\Casing\NativeTypeDeclarationCasingFixer;
@@ -232,6 +233,8 @@ return ECSConfig::configure()
             WhitespaceAfterCommaInArrayFixer::class,
             // Classes must be in a path that matches their namespace
             PsrAutoloadingFixer::class,
+            // When referencing an internal class it must be written using the correct casing.
+            ClassReferenceNameCasingFixer::class,
             // Magic method definitions and calls must be using the correct casing
             MagicMethodCasingFixer::class,
             // Function defined by PHP should be called using the correct casing

--- a/ecs.php
+++ b/ecs.php
@@ -285,9 +285,9 @@ return ECSConfig::configure()
             NoUnreachableDefaultArgumentValueFixer::class,
             // There must be no `sprintf` calls with only the first argument.
             NoUselessSprintfFixer::class,
-
+            // There must not be a space before colon in return type declarations.
             ReturnTypeDeclarationFixer::class,
-
+            // Add `void` return type to functions with missing or empty return statements.
             VoidReturnFixer::class,
             // Remove leading slashes in `use` clauses.
             NoLeadingImportSlashFixer::class,
@@ -307,15 +307,15 @@ return ECSConfig::configure()
             CleanNamespaceFixer::class,
             // The namespace declaration line shouldn't contain leading whitespace.
             NoLeadingNamespaceWhitespaceFixer::class,
-
+            // Binary operators should be surrounded by exactly one single space.
             BinaryOperatorSpacesFixer::class,
             // There must be no space around scope resolution double colons
             NoSpaceAroundDoubleColonFixer::class,
-
+            // All instances created with new keyword must be followed by parentheses.
             NewWithParenthesesFixer::class,
-
+            // There should not be space before or after object operators `->` and `?->`.
             ObjectOperatorWithoutWhitespaceFixer::class,
-
+            // Replace all `<>` with `!=`.
             StandardizeNotEqualsFixer::class,
             // Standardize spaces around ternary operator.
             TernaryOperatorSpacesFixer::class,
@@ -323,7 +323,7 @@ return ECSConfig::configure()
             TernaryToElvisOperatorFixer::class,
             // Use `null` coalescing operator `??` where possible.
             TernaryToNullCoalescingFixer::class,
-
+            // Unary operators should be placed adjacent (without a space) to their operands.
             UnaryOperatorSpacesFixer::class,
 
             NoBlankLinesAfterPhpdocFixer::class,

--- a/ecs.php
+++ b/ecs.php
@@ -226,7 +226,7 @@ return ECSConfig::configure()
             SetTypeToCastFixer::class,
             // Array index should always be written by using square braces
             NormalizeIndexBraceFixer::class,
-            // PHP single-line arrays should not have trailing comma
+            // Values separated by a comma on a single line should not have a trailing comma.
             NoTrailingCommaInSinglelineFixer::class,
             // Multi-line arrays, arguments list and parameters list must have a trailing comma
             TrailingCommaInMultilineFixer::class,

--- a/ecs.php
+++ b/ecs.php
@@ -76,6 +76,7 @@ use PhpCsFixer\Fixer\FunctionNotation\PhpdocToReturnTypeFixer;
 use PhpCsFixer\Fixer\FunctionNotation\ReturnTypeDeclarationFixer;
 use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
 use PhpCsFixer\Fixer\Import\NoLeadingImportSlashFixer;
+use PhpCsFixer\Fixer\Import\NoUnneededImportAliasFixer;
 use PhpCsFixer\Fixer\Import\NoUnusedImportsFixer;
 use PhpCsFixer\Fixer\Import\OrderedImportsFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\DeclareEqualNormalizeFixer;
@@ -281,13 +282,15 @@ return ECSConfig::configure()
             ReturnTypeDeclarationFixer::class,
 
             VoidReturnFixer::class,
-
+            // Remove leading slashes in `use` clauses.
             NoLeadingImportSlashFixer::class,
-
+            // Imports should not be aliased as the same name.
+            NoUnneededImportAliasFixer::class,
+            // Unused `use` statements must be removed.
             NoUnusedImportsFixer::class,
-
+            // Order `use` statements.
             OrderedImportsFixer::class,
-
+            // Equal sign in declare statement should not be surrounded by spaces.
             DeclareEqualNormalizeFixer::class,
             // Replaces `is_null($var)` expression with `null === $var`
             IsNullFixer::class,

--- a/ecs.php
+++ b/ecs.php
@@ -68,6 +68,7 @@ use PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer;
 use PhpCsFixer\Fixer\FunctionNotation\CombineNestedDirnameFixer;
 use PhpCsFixer\Fixer\FunctionNotation\FopenFlagOrderFixer;
 use PhpCsFixer\Fixer\FunctionNotation\FopenFlagsFixer;
+use PhpCsFixer\Fixer\FunctionNotation\FunctionDeclarationFixer;
 use PhpCsFixer\Fixer\FunctionNotation\ImplodeCallFixer;
 use PhpCsFixer\Fixer\FunctionNotation\LambdaNotUsedImportFixer;
 use PhpCsFixer\Fixer\FunctionNotation\NoUnreachableDefaultArgumentValueFixer;
@@ -542,6 +543,11 @@ return ECSConfig::configure()
                 'method',
             ],
         ],
+    )
+    // Spaces should be properly placed in a function declaration.
+    ->withConfiguredRule(
+        FunctionDeclarationFixer::class,
+        ['closure_fn_spacing' => 'none'], // Defined in PER 2.0
     )
     ->withSkip([
         // We allow empty catch statements (but they must have comment - see EmptyCatchCommentSniff)

--- a/ecs.php
+++ b/ecs.php
@@ -93,6 +93,7 @@ use PhpCsFixer\Fixer\NamespaceNotation\CleanNamespaceFixer;
 use PhpCsFixer\Fixer\NamespaceNotation\NoLeadingNamespaceWhitespaceFixer;
 use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
 use PhpCsFixer\Fixer\Operator\ConcatSpaceFixer;
+use PhpCsFixer\Fixer\Operator\LongToShorthandOperatorFixer;
 use PhpCsFixer\Fixer\Operator\NewWithParenthesesFixer;
 use PhpCsFixer\Fixer\Operator\NoSpaceAroundDoubleColonFixer;
 use PhpCsFixer\Fixer\Operator\ObjectOperatorWithoutWhitespaceFixer;
@@ -311,6 +312,8 @@ return ECSConfig::configure()
             NoLeadingNamespaceWhitespaceFixer::class,
             // Binary operators should be surrounded by exactly one single space.
             BinaryOperatorSpacesFixer::class,
+            // Shorthand notation for operators should be used if possible.
+            LongToShorthandOperatorFixer::class,
             // There must be no space around scope resolution double colons
             NoSpaceAroundDoubleColonFixer::class,
             // All instances created with new keyword must be followed by parentheses.

--- a/ecs.php
+++ b/ecs.php
@@ -215,8 +215,6 @@ return ECSConfig::configure()
             ArrayPushFixer::class,
             // Replace non multibyte-safe functions with corresponding mb function
             MbStrFunctionsFixer::class,
-            // Master functions shall be used instead of aliases
-            NoAliasFunctionsFixer::class,
             // Replaces `rand`, `srand`, `getrandmax` functions calls with their `mt_*` analogs
             RandomApiMigrationFixer::class,
             // Cast shall be used, not `settype()`
@@ -458,6 +456,8 @@ return ECSConfig::configure()
             'var_dump' => null,
         ],
     ])
+    // Master functions shall be used instead of aliases
+    ->withConfiguredRule(NoAliasFunctionsFixer::class, ['sets' => ['@all']])
     // There should be exactly one blank line before a namespace declaration.
     ->withConfiguredRule(BlankLinesBeforeNamespaceFixer::class, ['min_line_breaks' => 2, 'max_line_breaks' => 2])
     // Proper operator spacing

--- a/ecs.php
+++ b/ecs.php
@@ -59,6 +59,7 @@ use PhpCsFixer\Fixer\ClassNotation\SelfAccessorFixer;
 use PhpCsFixer\Fixer\ClassNotation\SingleTraitInsertPerStatementFixer;
 use PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer;
 use PhpCsFixer\Fixer\Comment\NoEmptyCommentFixer;
+use PhpCsFixer\Fixer\Comment\SingleLineCommentSpacingFixer;
 use PhpCsFixer\Fixer\ControlStructure\NoUselessElseFixer;
 use PhpCsFixer\Fixer\ControlStructure\SwitchContinueToBreakFixer;
 use PhpCsFixer\Fixer\ControlStructure\TrailingCommaInMultilineFixer;
@@ -256,6 +257,8 @@ return ECSConfig::configure()
             SingleTraitInsertPerStatementFixer::class,
             // There should not be any empty comments
             NoEmptyCommentFixer::class,
+            // Single-line comments must have proper spacing.
+            SingleLineCommentSpacingFixer::class,
             // There should not be useless `else` cases
             NoUselessElseFixer::class,
             // Switch case must not be ended with `continue` but with `break`.

--- a/ecs.php
+++ b/ecs.php
@@ -50,6 +50,7 @@ use PhpCsFixer\Fixer\Basic\OctalNotationFixer;
 use PhpCsFixer\Fixer\Basic\PsrAutoloadingFixer;
 use PhpCsFixer\Fixer\Basic\SingleLineEmptyBodyFixer;
 use PhpCsFixer\Fixer\Casing\ClassReferenceNameCasingFixer;
+use PhpCsFixer\Fixer\Casing\MagicConstantCasingFixer;
 use PhpCsFixer\Fixer\Casing\MagicMethodCasingFixer;
 use PhpCsFixer\Fixer\Casing\NativeFunctionCasingFixer;
 use PhpCsFixer\Fixer\Casing\NativeTypeDeclarationCasingFixer;
@@ -259,6 +260,8 @@ return ECSConfig::configure()
             PsrAutoloadingFixer::class,
             // When referencing an internal class it must be written using the correct casing.
             ClassReferenceNameCasingFixer::class,
+            // Magic constants should be referred to using the correct casing.
+            MagicConstantCasingFixer::class,
             // Magic method definitions and calls must be using the correct casing
             MagicMethodCasingFixer::class,
             // Function defined by PHP should be called using the correct casing

--- a/ecs.php
+++ b/ecs.php
@@ -46,6 +46,7 @@ use PhpCsFixer\Fixer\ArrayNotation\WhitespaceAfterCommaInArrayFixer;
 use PhpCsFixer\Fixer\AttributeNotation\AttributeEmptyParenthesesFixer;
 use PhpCsFixer\Fixer\Basic\BracesFixer;
 use PhpCsFixer\Fixer\Basic\NoTrailingCommaInSinglelineFixer;
+use PhpCsFixer\Fixer\Basic\OctalNotationFixer;
 use PhpCsFixer\Fixer\Basic\PsrAutoloadingFixer;
 use PhpCsFixer\Fixer\Basic\SingleLineEmptyBodyFixer;
 use PhpCsFixer\Fixer\Casing\ClassReferenceNameCasingFixer;
@@ -245,6 +246,8 @@ return ECSConfig::configure()
             SingleLineEmptyBodyFixer::class, // Defined in PER 2.0
             // Values separated by a comma on a single line should not have a trailing comma.
             NoTrailingCommaInSinglelineFixer::class,
+            // Literal octal must be in 0o notation.
+            OctalNotationFixer::class,
             // Arrays should be formatted like function/method arguments
             TrimArraySpacesFixer::class,
             // In array declaration, there MUST be a whitespace after each comma

--- a/ecs.php
+++ b/ecs.php
@@ -124,6 +124,7 @@ use PhpCsFixer\Fixer\Phpdoc\PhpdocReturnSelfReferenceFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocScalarFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocSingleLineVarSpacingFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocToCommentFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocTrimConsecutiveBlankLineSeparationFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocTrimFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocTypesFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocVarAnnotationCorrectOrderFixer;
@@ -372,6 +373,8 @@ return ECSConfig::configure()
             PhpdocScalarFixer::class,
             // Single line `@var` PHPDoc should have proper spacing.
             PhpdocSingleLineVarSpacingFixer::class,
+            // Removes extra blank lines after summary and after description in PHPDoc.
+            PhpdocTrimConsecutiveBlankLineSeparationFixer::class,
             // PHPDoc should start and end with content
             PhpdocTrimFixer::class,
             // Docblocks should only be used on structural elements.

--- a/ecs.php
+++ b/ecs.php
@@ -135,6 +135,7 @@ use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
 use PhpCsFixer\Fixer\Strict\StrictParamFixer;
 use PhpCsFixer\Fixer\StringNotation\SingleQuoteFixer;
+use PhpCsFixer\Fixer\Whitespace\ArrayIndentationFixer;
 use PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer;
 use PhpCsFixer\Fixer\Whitespace\CompactNullableTypeDeclarationFixer;
 use PhpCsFixer\Fixer\Whitespace\HeredocIndentationFixer;
@@ -385,6 +386,8 @@ return ECSConfig::configure()
             StrictComparisonFixer::class,
             // Convert double quotes to single quotes for simple strings
             SingleQuoteFixer::class,
+            // Each element of an array must be indented exactly once.
+            ArrayIndentationFixer::class,
             // Remove extra spaces in a nullable typehint
             CompactNullableTypeDeclarationFixer::class,
             // Heredoc/nowdoc content must be properly indented.

--- a/ecs.php
+++ b/ecs.php
@@ -87,6 +87,7 @@ use PhpCsFixer\Fixer\NamespaceNotation\NoLeadingNamespaceWhitespaceFixer;
 use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
 use PhpCsFixer\Fixer\Operator\ConcatSpaceFixer;
 use PhpCsFixer\Fixer\Operator\NewWithParenthesesFixer;
+use PhpCsFixer\Fixer\Operator\NoSpaceAroundDoubleColonFixer;
 use PhpCsFixer\Fixer\Operator\ObjectOperatorWithoutWhitespaceFixer;
 use PhpCsFixer\Fixer\Operator\StandardizeNotEqualsFixer;
 use PhpCsFixer\Fixer\Operator\TernaryOperatorSpacesFixer;
@@ -295,6 +296,8 @@ return ECSConfig::configure()
             NoLeadingNamespaceWhitespaceFixer::class,
 
             BinaryOperatorSpacesFixer::class,
+            // There must be no space around scope resolution double colons
+            NoSpaceAroundDoubleColonFixer::class,
 
             NewWithParenthesesFixer::class,
 

--- a/ecs.php
+++ b/ecs.php
@@ -102,6 +102,7 @@ use PhpCsFixer\Fixer\Phpdoc\NoBlankLinesAfterPhpdocFixer;
 use PhpCsFixer\Fixer\Phpdoc\NoEmptyPhpdocFixer;
 use PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocAddMissingParamAnnotationFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocAlignFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocIndentFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocNoAccessFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocNoEmptyReturnFixer;
@@ -499,6 +500,8 @@ return ECSConfig::configure()
         'allow_unused_params' => false, // whether param annotation without actual signature is allowed
         'remove_inheritdoc' => true, // remove @inheritDoc tags
     ])
+    // All items of the given PHPDoc tags must be left-aligned.
+    ->withConfiguredRule(PhpdocAlignFixer::class, ['align' => 'left'])
     // Order phpdoc tags by value.
     ->withConfiguredRule(PhpdocOrderByValueFixer::class, ['annotations' => ['covers', 'group', 'throws']])
     // Calls to `PHPUnit\Framework\TestCase` static methods must all be of the same type (`$this->...`)

--- a/ecs.php
+++ b/ecs.php
@@ -89,6 +89,7 @@ use PhpCsFixer\Fixer\Import\NoUnusedImportsFixer;
 use PhpCsFixer\Fixer\Import\OrderedImportsFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\DeclareEqualNormalizeFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\IsNullFixer;
+use PhpCsFixer\Fixer\LanguageConstruct\NullableTypeDeclarationFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\SingleSpaceAroundConstructFixer;
 use PhpCsFixer\Fixer\ListNotation\ListSyntaxFixer;
 use PhpCsFixer\Fixer\NamespaceNotation\BlankLinesBeforeNamespaceFixer;
@@ -311,6 +312,8 @@ return ECSConfig::configure()
             DeclareEqualNormalizeFixer::class,
             // Replaces `is_null($var)` expression with `null === $var`
             IsNullFixer::class,
+            // Nullable single type declaration should be standardised using question mark syntax.
+            NullableTypeDeclarationFixer::class,
             // Ensures a single space around language constructs.
             SingleSpaceAroundConstructFixer::class,
             // Namespace must not contain spacing, comments or PHPDoc.

--- a/ecs.php
+++ b/ecs.php
@@ -135,6 +135,7 @@ use PhpCsFixer\Fixer\Whitespace\HeredocIndentationFixer;
 use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
 use PhpCsFixer\Fixer\Whitespace\NoWhitespaceInBlankLineFixer;
 use PhpCsFixer\Fixer\Whitespace\TypeDeclarationSpacesFixer;
+use PhpCsFixer\Fixer\Whitespace\TypesSpacesFixer;
 use SlevomatCodingStandard\Sniffs\Classes\RequireConstructorPropertyPromotionSniff;
 use SlevomatCodingStandard\Sniffs\ControlStructures\RequireNullSafeObjectOperatorSniff;
 use SlevomatCodingStandard\Sniffs\Exceptions\ReferenceThrowableOnlySniff;
@@ -143,7 +144,6 @@ use SlevomatCodingStandard\Sniffs\Functions\RequireTrailingCommaInDeclarationSni
 use SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff;
-use SlevomatCodingStandard\Sniffs\TypeHints\UnionTypeHintFormatSniff;
 use Symplify\CodingStandard\Fixer\Commenting\ParamReturnAndVarTagMalformsFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 
@@ -263,6 +263,8 @@ return ECSConfig::configure()
             FopenFlagsFixer::class,
             // Add missing space between function's argument and its typehint.
             TypeDeclarationSpacesFixer::class,
+            // None space should be around union type and intersection type operators.
+            TypesSpacesFixer::class,
             // Function `implode` must be called with 2 arguments in the documented order.
             ImplodeCallFixer::class,
             // Lambda must not import variables it doesn't use.
@@ -505,8 +507,6 @@ return ECSConfig::configure()
             'use_trait',
         ],
     ])
-    // Format union types
-    ->withConfiguredRule(UnionTypeHintFormatSniff::class, ['withSpaces' => 'no'])
     ->withSkip([
         // We allow empty catch statements (but they must have comment - see EmptyCatchCommentSniff)
         EmptyStatementSniff::class . '.DetectedCatch' => null,

--- a/ecs.php
+++ b/ecs.php
@@ -64,7 +64,6 @@ use PhpCsFixer\Fixer\ClassNotation\SelfAccessorFixer;
 use PhpCsFixer\Fixer\ClassNotation\SingleTraitInsertPerStatementFixer;
 use PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer;
 use PhpCsFixer\Fixer\Comment\NoEmptyCommentFixer;
-use PhpCsFixer\Fixer\Comment\SingleLineCommentSpacingFixer;
 use PhpCsFixer\Fixer\ControlStructure\NoUnneededControlParenthesesFixer;
 use PhpCsFixer\Fixer\ControlStructure\NoUselessElseFixer;
 use PhpCsFixer\Fixer\ControlStructure\SwitchContinueToBreakFixer;
@@ -148,7 +147,6 @@ use PhpCsFixer\Fixer\Semicolon\SpaceAfterSemicolonFixer;
 use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
 use PhpCsFixer\Fixer\Strict\StrictParamFixer;
-use PhpCsFixer\Fixer\StringNotation\MultilineStringToHeredocFixer;
 use PhpCsFixer\Fixer\StringNotation\SimpleToComplexStringVariableFixer;
 use PhpCsFixer\Fixer\StringNotation\SingleQuoteFixer;
 use PhpCsFixer\Fixer\Whitespace\ArrayIndentationFixer;
@@ -283,8 +281,6 @@ return ECSConfig::configure()
             SingleTraitInsertPerStatementFixer::class,
             // There should not be any empty comments
             NoEmptyCommentFixer::class,
-            // Single-line comments must have proper spacing.
-            SingleLineCommentSpacingFixer::class,
             // There should not be useless `else` cases
             NoUselessElseFixer::class,
             // Switch case must not be ended with `continue` but with `break`.
@@ -417,8 +413,6 @@ return ECSConfig::configure()
             StrictParamFixer::class,
             // Comparisons should be strict, `===` or `!==` must be used for comparisons
             StrictComparisonFixer::class,
-            // Convert multiline string to heredoc or nowdoc.
-            MultilineStringToHeredocFixer::class,
             // Converts explicit variables in double-quoted strings from simple to complex format (${ to {$).
             SimpleToComplexStringVariableFixer::class,
             // Convert double quotes to single quotes for simple strings

--- a/ecs.php
+++ b/ecs.php
@@ -43,6 +43,7 @@ use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use PhpCsFixer\Fixer\ArrayNotation\NormalizeIndexBraceFixer;
 use PhpCsFixer\Fixer\ArrayNotation\TrimArraySpacesFixer;
 use PhpCsFixer\Fixer\ArrayNotation\WhitespaceAfterCommaInArrayFixer;
+use PhpCsFixer\Fixer\AttributeNotation\AttributeEmptyParenthesesFixer;
 use PhpCsFixer\Fixer\Basic\BracesFixer;
 use PhpCsFixer\Fixer\Basic\NoTrailingCommaInSinglelineFixer;
 use PhpCsFixer\Fixer\Basic\PsrAutoloadingFixer;
@@ -72,6 +73,7 @@ use PhpCsFixer\Fixer\FunctionNotation\FopenFlagsFixer;
 use PhpCsFixer\Fixer\FunctionNotation\FunctionDeclarationFixer;
 use PhpCsFixer\Fixer\FunctionNotation\ImplodeCallFixer;
 use PhpCsFixer\Fixer\FunctionNotation\LambdaNotUsedImportFixer;
+use PhpCsFixer\Fixer\FunctionNotation\MethodArgumentSpaceFixer;
 use PhpCsFixer\Fixer\FunctionNotation\NoUnreachableDefaultArgumentValueFixer;
 use PhpCsFixer\Fixer\FunctionNotation\NoUselessSprintfFixer;
 use PhpCsFixer\Fixer\FunctionNotation\PhpdocToParamTypeFixer;
@@ -148,6 +150,8 @@ use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
 use PhpCsFixer\Fixer\Whitespace\NoWhitespaceInBlankLineFixer;
 use PhpCsFixer\Fixer\Whitespace\TypeDeclarationSpacesFixer;
 use PhpCsFixer\Fixer\Whitespace\TypesSpacesFixer;
+use SlevomatCodingStandard\Sniffs\Attributes\DisallowAttributesJoiningSniff;
+use SlevomatCodingStandard\Sniffs\Attributes\DisallowMultipleAttributesPerLineSniff;
 use SlevomatCodingStandard\Sniffs\Classes\RequireConstructorPropertyPromotionSniff;
 use SlevomatCodingStandard\Sniffs\ControlStructures\RequireNullSafeObjectOperatorSniff;
 use SlevomatCodingStandard\Sniffs\Exceptions\ReferenceThrowableOnlySniff;
@@ -230,6 +234,8 @@ return ECSConfig::configure()
             RandomApiMigrationFixer::class,
             // Cast shall be used, not `settype()`
             SetTypeToCastFixer::class,
+            // Attributes declared without arguments must not be followed by empty parentheses.
+            AttributeEmptyParenthesesFixer::class,
             // Array index should always be written by using square braces
             NormalizeIndexBraceFixer::class,
             // Empty body of class, interface, trait, enum or function must be abbreviated as {} and placed on the same line as the previous symbol, separated by a single space.
@@ -415,6 +421,10 @@ return ECSConfig::configure()
             // Takes `@return` annotation of non-mixed types and adjusts accordingly the function signature.
             PhpdocToReturnTypeFixer::class,
             ReturnTypeHintSniff::class,
+            // Requires that only one attribute can be placed inside #[].
+            DisallowAttributesJoiningSniff::class,
+            // Disallows multiple attributes of some target on same line.
+            DisallowMultipleAttributesPerLineSniff::class,
             // Promote constructor properties
             // For php-cs-fixer implementation @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5956
             RequireConstructorPropertyPromotionSniff::class,
@@ -520,13 +530,15 @@ return ECSConfig::configure()
     // Removes extra blank lines and/or blank lines following configuration
     ->withConfiguredRule(NoExtraBlankLinesFixer::class, [
         'tokens' => [
-            'break',
+            'attribute',
+            'case',
             'continue',
             'curly_brace_block',
+            'default',
             'extra',
             'parenthesis_brace_block',
-            'return',
             'square_brace_block',
+            'switch',
             'throw',
             'use',
             'use_trait',
@@ -563,6 +575,11 @@ return ECSConfig::configure()
     ->withConfiguredRule(
         FullyQualifiedStrictTypesFixer::class,
         ['import_symbols' => true], // Also import symbols from other namespaces than in current file
+    )
+    // Spaces and newlines in method arguments and attributes
+    ->withConfiguredRule(
+        MethodArgumentSpaceFixer::class,
+        ['attribute_placement' => 'standalone', 'on_multiline' => 'ensure_fully_multiline'],
     )
     ->withSkip([
         // We allow empty catch statements (but they must have comment - see EmptyCatchCommentSniff)

--- a/ecs.php
+++ b/ecs.php
@@ -79,6 +79,7 @@ use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
 use PhpCsFixer\Fixer\FunctionNotation\PhpdocToReturnTypeFixer;
 use PhpCsFixer\Fixer\FunctionNotation\ReturnTypeDeclarationFixer;
 use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
+use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
 use PhpCsFixer\Fixer\Import\NoLeadingImportSlashFixer;
 use PhpCsFixer\Fixer\Import\NoUnneededImportAliasFixer;
 use PhpCsFixer\Fixer\Import\NoUnusedImportsFixer;
@@ -551,6 +552,11 @@ return ECSConfig::configure()
     ->withConfiguredRule(
         TrailingCommaInMultilineFixer::class,
         ['after_heredoc' => true, 'elements' => ['arguments', 'arrays', 'match', 'parameters']], // Defined in PER 2.0
+    )
+    // Removes the leading part of FQCN
+    ->withConfiguredRule(
+        FullyQualifiedStrictTypesFixer::class,
+        ['import_symbols' => true], // Also import symbols from other namespaces than in current file
     )
     ->withSkip([
         // We allow empty catch statements (but they must have comment - see EmptyCatchCommentSniff)

--- a/ecs.php
+++ b/ecs.php
@@ -46,6 +46,7 @@ use PhpCsFixer\Fixer\ArrayNotation\WhitespaceAfterCommaInArrayFixer;
 use PhpCsFixer\Fixer\Basic\BracesFixer;
 use PhpCsFixer\Fixer\Basic\NoTrailingCommaInSinglelineFixer;
 use PhpCsFixer\Fixer\Basic\PsrAutoloadingFixer;
+use PhpCsFixer\Fixer\Basic\SingleLineEmptyBodyFixer;
 use PhpCsFixer\Fixer\Casing\ClassReferenceNameCasingFixer;
 use PhpCsFixer\Fixer\Casing\MagicMethodCasingFixer;
 use PhpCsFixer\Fixer\Casing\NativeFunctionCasingFixer;
@@ -229,6 +230,8 @@ return ECSConfig::configure()
             SetTypeToCastFixer::class,
             // Array index should always be written by using square braces
             NormalizeIndexBraceFixer::class,
+            // Empty body of class, interface, trait, enum or function must be abbreviated as {} and placed on the same line as the previous symbol, separated by a single space.
+            SingleLineEmptyBodyFixer::class, // Defined in PER 2.0
             // Values separated by a comma on a single line should not have a trailing comma.
             NoTrailingCommaInSinglelineFixer::class,
             // Multi-line arrays, arguments list and parameters list must have a trailing comma

--- a/src/Helper/SniffClassWrapper.php
+++ b/src/Helper/SniffClassWrapper.php
@@ -33,9 +33,7 @@ use SlevomatCodingStandard\Helpers\TokenHelper;
 
 final class SniffClassWrapper
 {
-    public function __construct(private File $file, private int $position, private Naming $naming)
-    {
-    }
+    public function __construct(private File $file, private int $position, private Naming $naming) {}
 
     public function getClassName(): ?string
     {

--- a/tests/Integration/CodingStandardTest.php
+++ b/tests/Integration/CodingStandardTest.php
@@ -53,6 +53,20 @@ class CodingStandardTest extends TestCase
         );
     }
 
+    /**
+     * @test
+     * @requires PHP >= 8.2
+     */
+    public function shouldFixPhp82(): void
+    {
+        $fixedFile = $this->runEcsCheckOnFile(__DIR__ . '/Fixtures/Php82.wrong.php.inc');
+
+        $this->assertStringEqualsFile(
+            __DIR__ . '/Fixtures/Php82.correct.php.inc',
+            file_get_contents($fixedFile),
+        );
+    }
+
     private function runEcsCheckOnFile(string $file): string
     {
         $fixtureFile = $this->initTempFixtureFile();

--- a/tests/Integration/CodingStandardTest.php
+++ b/tests/Integration/CodingStandardTest.php
@@ -36,6 +36,7 @@ class CodingStandardTest extends TestCase
                 __DIR__ . '/Fixtures/NewPhpFeatures.wrong.php.inc',
                 __DIR__ . '/Fixtures/NewPhpFeatures.correct.php.inc',
             ],
+            'PhpDoc' => [__DIR__ . '/Fixtures/PhpDoc.wrong.php.inc', __DIR__ . '/Fixtures/PhpDoc.correct.php.inc'],
         ];
     }
 

--- a/tests/Integration/CodingStandardTest.php
+++ b/tests/Integration/CodingStandardTest.php
@@ -39,6 +39,20 @@ class CodingStandardTest extends TestCase
         ];
     }
 
+    /**
+     * @test
+     * @requires PHP >= 8.1
+     */
+    public function shouldFixPhp81(): void
+    {
+        $fixedFile = $this->runEcsCheckOnFile(__DIR__ . '/Fixtures/Php81.wrong.php.inc');
+
+        $this->assertStringEqualsFile(
+            __DIR__ . '/Fixtures/Php81.correct.php.inc',
+            file_get_contents($fixedFile),
+        );
+    }
+
     private function runEcsCheckOnFile(string $file): string
     {
         $fixtureFile = $this->initTempFixtureFile();

--- a/tests/Integration/CodingStandardTest.php
+++ b/tests/Integration/CodingStandardTest.php
@@ -37,6 +37,7 @@ class CodingStandardTest extends TestCase
                 __DIR__ . '/Fixtures/NewPhpFeatures.correct.php.inc',
             ],
             'PhpDoc' => [__DIR__ . '/Fixtures/PhpDoc.wrong.php.inc', __DIR__ . '/Fixtures/PhpDoc.correct.php.inc'],
+            'PhpUnit' => [__DIR__ . '/Fixtures/PhpUnit.wrong.php.inc', __DIR__ . '/Fixtures/PhpUnit.correct.php.inc'],
         ];
     }
 

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -63,6 +63,12 @@ class Basic extends AbstractBasic implements InterfaceFromThisNamespace // Fully
             $baz = implode(',', ['foo', 'bar']);
         }
 
+        $i = 3;
+        $i += 6; // LongToShorthandOperatorFixer
+        $i *= 2; // LongToShorthandOperatorFixer
+        $text = 'foo';
+        $text .= 'bar'; // LongToShorthandOperatorFixer
+
         // HeredocIndentationFixer
         $heredoc = <<<HEREDOC
             This is a

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -83,8 +83,8 @@ class Basic
      * It tests PhpdocAlignFixer, NoSuperfluousPhpdocTagsFixer and possibly other Phpdoc rules.
      * @param int|float $second Second parameter does have a comment, unlike the first one.
      * @param string|null $third Third parameter is optional and has a default value.
-     * @throws \Exception
      * @return mixed There is also information about return type.
+     * @throws \Exception
      */
     public function veryWellDocumented(string $first, int|float $second, ?string $third = '3rd'): mixed
     {

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -170,4 +170,7 @@ class Basic extends AbstractBasic implements InterfaceFromThisNamespace // Fully
             2,
         );
     }
+
+    // NullableTypeDeclarationFixer
+    public function withParameters(?string $nullableValue): void {}
 }

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -1,8 +1,12 @@
 <?php declare(strict_types=1);
 
-use Bar\Foo; // NoUnneededImportAliasFixer
+namespace Lmc\CodingStandard\Integration\Fixtures;
 
-class Basic
+// NoUnneededImportAliasFixer
+use Bar\Foo;
+use Some\Other\Namespace\AbstractBasic;
+
+class Basic extends AbstractBasic implements InterfaceFromThisNamespace // FullyQualifiedStrictTypesFixer
 {
     use SomeUsefulTrait; // OrderedClassElementsFixer
     public const FOO = 'foo'; // ClassAttributesSeparationFixer

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -4,7 +4,7 @@ class Basic
 {
     public const FOO = 'foo'; // ClassAttributesSeparationFixer
 
-    public function isEqual($a, $b) // VisibilityRequiredFixer
+    public function isEqual($a, ?string $b): ?bool // VisibilityRequiredFixer, CompactNullableTypeDeclarationFixer
     {
         // TrimArraySpacesFixer
         $fooBar = ['a', 'b'];
@@ -16,6 +16,8 @@ class Basic
         $uselessSprintf = 'bar';
         // StrictParamFixer
         $useStrictParam = in_array(1337, $fooBar, true);
+        // NoSpaceAroundDoubleColonFixer
+        $className = DateTime::class;
         // SingleSpaceAfterConstructFixer, StrictComparisonFixer
         if ($a === $b || $bazLength !== 3) {
             return true;

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Bar\Foo; // NoUnneededImportAliasFixer
+
 class Basic
 {
     public const FOO = 'foo'; // ClassAttributesSeparationFixer
@@ -20,6 +22,9 @@ class Basic
         $className = DateTime::class;
         // ClassReferenceNameCasingFixer
         $date = new \DateTime();
+
+        $aliasedClass = new Foo();
+
         // SingleSpaceAfterConstructFixer, StrictComparisonFixer
         if ($a === $b || $bazLength !== 3) {
             return true;

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -4,7 +4,12 @@ use Bar\Foo; // NoUnneededImportAliasFixer
 
 class Basic
 {
+    use SomeUsefulTrait; // OrderedClassElementsFixer
     public const FOO = 'foo'; // ClassAttributesSeparationFixer
+
+    public const MY_PUBLIC_CONST = 333; // OrderedClassElementsFixer
+
+    protected int $myProperty = 666; // OrderedClassElementsFixer
 
     public function isEqual($a, ?string $b): ?bool // VisibilityRequiredFixer, CompactNullableTypeDeclarationFixer
     {

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -77,4 +77,17 @@ class Basic
             'third' => 'bat',
         ];
     }
+
+    /**
+     * Very well documented method.
+     * It tests PhpdocAlignFixer, NoSuperfluousPhpdocTagsFixer and possibly other Phpdoc rules.
+     * @param int|float $second Second parameter does have a comment, unlike the first one.
+     * @param string|null $third Third parameter is optional and has a default value.
+     * @throws \Exception
+     * @return mixed There is also information about return type.
+     */
+    public function veryWellDocumented(string $first, int|float $second, ?string $third = '3rd'): mixed
+    {
+        return $first . $third;
+    }
 }

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -110,4 +110,29 @@ class Basic
     public function emptyFunction2(
         $arg,
     ): void {} // SingleLineEmptyBodyFixer
+
+    // TrailingCommaInMultilineFixer
+    public function multiline(
+        $arg1,
+        $arg2,
+        $arg3,
+    ): void {
+        // TrailingCommaInMultilineFixer
+        $isSet = isset(
+            $arg1,
+            $arg2,
+            $arg3,
+        );
+
+        $sprintf = sprintf(
+            '%s%s',
+            'bar',
+            'baz',
+        );
+
+        foo(
+            1,
+            2,
+        );
+    }
 }

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -15,6 +15,8 @@ class Basic
     {
         // TrimArraySpacesFixer
         $fooBar = ['a', 'b'];
+        // NoTrailingCommaInSinglelineFixer
+        mb_strlen('foobar');
         // MbStrFunctionsFixer
         $bazLength = mb_strlen('baz');
         // LambdaNotUsedImportFixer
@@ -55,5 +57,24 @@ class Basic
 
         // TernaryToElvisOperatorFixer
         return ($foo ?: 'not true');
+    }
+
+    public function arrayDeclarations(): void
+    {
+        $empty = [];
+
+        $singleLineArray = ['foo', 'bar', 'baz'];
+        $singleLineArray2 = [1, 2, 3];
+
+        $multiLineAssociative = [
+            'foo' => 'bar',
+            'baz' => 'bat',
+        ];
+
+        $multiLineAssociative2 = [
+            'firstKey' => 'bar',
+            'thisIsSecondKey' => 'bat',
+            'third' => 'bat',
+        ];
     }
 }

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -18,6 +18,8 @@ class Basic
         $useStrictParam = in_array(1337, $fooBar, true);
         // NoSpaceAroundDoubleColonFixer
         $className = DateTime::class;
+        // ClassReferenceNameCasingFixer
+        $date = new \DateTime();
         // SingleSpaceAfterConstructFixer, StrictComparisonFixer
         if ($a === $b || $bazLength !== 3) {
             return true;

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -26,6 +26,13 @@ class Basic
 
     public function fooBar(mixed $foo): mixed
     {
+        // PhpdocToCommentFixer
+        /*
+         * Phpdoc used instead of plain comment
+         */
+        if ($foo === 'bar') {
+            $baz = 'bat';
+        }
         // TernaryToElvisOperatorFixer
         return ($foo ?: 'not true');
     }

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -44,6 +44,10 @@ class Basic
             $baz = implode(',', ['foo', 'bar']);
         }
 
+        // SingleLineCommentSpacingFixer
+        // This comment should have space on the beginning
+        /* So should this one, also with space on the end */
+
         // TernaryToElvisOperatorFixer
         return ($foo ?: 'not true');
     }

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -31,8 +31,10 @@ class Basic
          * Phpdoc used instead of plain comment
          */
         if ($foo === 'bar') {
-            $baz = 'bat';
+            // NoAliasFunctionsFixer
+            $baz = implode(',', ['foo', 'bar']);
         }
+
         // TernaryToElvisOperatorFixer
         return ($foo ?: 'not true');
     }

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -95,16 +95,6 @@ class Basic extends AbstractBasic implements InterfaceFromThisNamespace // Fully
         $newdoc = <<<'NEWDOC'
             This is a $newdoc, where variables are not expanded.
             NEWDOC;
-        // MultilineStringToHeredocFixer
-        $multilineString = <<<'EOD'
-            This string
-            spans multiple lines
-            but should be heredoc instead
-            EOD;
-
-        // SingleLineCommentSpacingFixer
-        // This comment should have space on the beginning
-        /* So should this one, also with space on the end */
 
         // TernaryToElvisOperatorFixer
         return ($foo ?: 'not true');

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -40,8 +40,16 @@ class Basic
         return false; // BlankLineBeforeStatementFixer
     }
 
-    public function fooBar(mixed $foo): mixed
+    public function fooBar(mixed $foo): mixed // FunctionDeclarationFixer
     {
+        $value = 5;
+        // FunctionDeclarationFixer
+        $function = function ($foo) use ($value) {
+            return $foo + $value;
+        };
+        // FunctionDeclarationFixer
+        $fn = fn($foo) => $foo + $value;
+
         // PhpdocToCommentFixer
         /*
          * Phpdoc used instead of plain comment

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -66,12 +66,18 @@ class Basic
         $singleLineArray = ['foo', 'bar', 'baz'];
         $singleLineArray2 = [1, 2, 3];
 
-        $multiLineAssociative = [
+        $multiLineAssociative1 = [
             'foo' => 'bar',
             'baz' => 'bat',
         ];
 
         $multiLineAssociative2 = [
+            'foo' => 'bar',
+            'baz' => 'bat',
+            'bak' => 'baz',
+        ];
+
+        $multiLineAssociative3 = [
             'firstKey' => 'bar',
             'thisIsSecondKey' => 'bat',
             'third' => 'bat',

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -63,6 +63,23 @@ class Basic extends AbstractBasic implements InterfaceFromThisNamespace // Fully
             $baz = implode(',', ['foo', 'bar']);
         }
 
+        // HeredocIndentationFixer
+        $heredoc = <<<HEREDOC
+            This is a
+            multiline heredoc string. It contains $foo.
+            It should be indented, though.
+            HEREDOC;
+        // HeredocIndentationFixer
+        $newdoc = <<<'NEWDOC'
+            This is a $newdoc, where variables are not expanded.
+            NEWDOC;
+        // MultilineStringToHeredocFixer
+        $multilineString = <<<'EOD'
+            This string
+            spans multiple lines
+            but should be heredoc instead
+            EOD;
+
         // SingleLineCommentSpacingFixer
         // This comment should have space on the beginning
         /* So should this one, also with space on the end */

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -69,6 +69,14 @@ class Basic extends AbstractBasic implements InterfaceFromThisNamespace // Fully
         $text = 'foo';
         $text .= 'bar'; // LongToShorthandOperatorFixer
 
+        switch ($i) {
+            case 1: // NoUnneededControlParenthesesFixer
+                $i++;
+                break;
+            default:
+                break;
+        }
+
         // HeredocIndentationFixer
         $heredoc = <<<HEREDOC
             This is a

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -15,6 +15,12 @@ class Basic extends AbstractBasic implements InterfaceFromThisNamespace // Fully
 
     protected int $myProperty = 666; // OrderedClassElementsFixer
 
+    // MagicMethodCasingFixer, OrderedClassElementsFixer
+    public function __toString(): string
+    {
+        return '';
+    }
+
     public function isEqual($a, ?string $b): ?bool // VisibilityRequiredFixer, CompactNullableTypeDeclarationFixer
     {
         // TrimArraySpacesFixer
@@ -46,6 +52,8 @@ class Basic extends AbstractBasic implements InterfaceFromThisNamespace // Fully
 
     public function fooBar(mixed $foo): mixed // FunctionDeclarationFixer
     {
+        // MagicConstantCasingFixer
+        $magicConstant = __DIR__;
         $value = 5;
         // FunctionDeclarationFixer
         $function = function ($foo) use ($value) {

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -171,6 +171,10 @@ class Basic extends AbstractBasic implements InterfaceFromThisNamespace // Fully
         );
     }
 
-    // NullableTypeDeclarationFixer
-    public function withParameters(?string $nullableValue): void {}
+    public function withParameters(
+        // NullableTypeDeclarationFixer
+        ?string $nullableValue,
+        // NullableTypeDeclarationForDefaultNullValueFixer
+        ?string $anotherNullableValue = null,
+    ): void {}
 }

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -127,19 +127,6 @@ class Basic extends AbstractBasic implements InterfaceFromThisNamespace // Fully
         ];
     }
 
-    /**
-     * Very well documented method.
-     * It tests PhpdocAlignFixer, NoSuperfluousPhpdocTagsFixer and possibly other Phpdoc rules.
-     * @param int|float $second Second parameter does have a comment, unlike the first one.
-     * @param string|null $third Third parameter is optional and has a default value.
-     * @return mixed There is also information about return type.
-     * @throws \Exception
-     */
-    public function veryWellDocumented(string $first, int|float $second, ?string $third = '3rd'): mixed
-    {
-        return $first . $third;
-    }
-
     public function emptyFunction1(): void {} // SingleLineEmptyBodyFixer
 
     public function emptyFunction2(

--- a/tests/Integration/Fixtures/Basic.correct.php.inc
+++ b/tests/Integration/Fixtures/Basic.correct.php.inc
@@ -104,4 +104,10 @@ class Basic
     {
         return $first . $third;
     }
+
+    public function emptyFunction1(): void {} // SingleLineEmptyBodyFixer
+
+    public function emptyFunction2(
+        $arg,
+    ): void {} // SingleLineEmptyBodyFixer
 }

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -22,6 +22,13 @@ class Basic
 
     public function fooBar(mixed $foo): mixed
     {
+        // PhpdocToCommentFixer
+        /**
+         * Phpdoc used instead of plain comment
+         */
+        if ($foo === 'bar') {
+            $baz = 'bat';
+        }
         // TernaryToElvisOperatorFixer
         return ($foo ? $foo : 'not true');
     }

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -9,6 +9,8 @@ class Basic
     {
         // TrimArraySpacesFixer
         $fooBar = [ 'a', 'b'];
+        // NoTrailingCommaInSinglelineFixer
+        mb_strlen('foobar', );
         // MbStrFunctionsFixer
         $bazLength = strlen('baz');
         // LambdaNotUsedImportFixer
@@ -53,4 +55,23 @@ class Basic
     protected int $myProperty = 666; // OrderedClassElementsFixer
 
     use SomeUsefulTrait; // OrderedClassElementsFixer
+
+    public function arrayDeclarations(): void
+    {
+        $empty = array();
+
+        $singleLineArray = ['foo', 'bar', 'baz',];
+        $singleLineArray2 = [1,2,3];
+
+        $multiLineAssociative = [
+            'foo'=>'bar',
+            'baz'=>'bat'
+        ];
+
+        $multiLineAssociative2 = [
+            'firstKey'        => 'bar',
+            'thisIsSecondKey' => 'bat',
+            'third'           => 'bat',
+        ];
+    }
 }

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -29,6 +29,8 @@ class Basic
         return false; // BlankLineBeforeStatementFixer
     }
 
+    public const MY_PUBLIC_CONST = 333; // OrderedClassElementsFixer
+
     public function fooBar(mixed $foo): mixed
     {
         // PhpdocToCommentFixer
@@ -47,4 +49,8 @@ class Basic
         // TernaryToElvisOperatorFixer
         return ($foo ? $foo : 'not true');
     }
+
+    protected int $myProperty = 666; // OrderedClassElementsFixer
+
+    use SomeUsefulTrait; // OrderedClassElementsFixer
 }

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -3,7 +3,7 @@
 class Basic
 {
     const FOO = 'foo'; // ClassAttributesSeparationFixer
-    function isEqual($a, $b) // VisibilityRequiredFixer
+    function isEqual($a, ? string $b): ? bool // VisibilityRequiredFixer, CompactNullableTypeDeclarationFixer
     {
         // TrimArraySpacesFixer
         $fooBar = [ 'a', 'b'];
@@ -15,6 +15,8 @@ class Basic
         $uselessSprintf = sprintf('bar');
         // StrictParamFixer
         $useStrictParam = in_array(1337, $fooBar);
+        // NoSpaceAroundDoubleColonFixer
+        $className = DateTime :: class;
         // SingleSpaceAfterConstructFixer, StrictComparisonFixer
         if ($a == $b || $bazLength != 3) { return  true; }
         return false; // BlankLineBeforeStatementFixer

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -63,12 +63,17 @@ class Basic
         $singleLineArray = ['foo', 'bar', 'baz',];
         $singleLineArray2 = [1,2,3];
 
-        $multiLineAssociative = [
-            'foo'=>'bar',
-            'baz'=>'bat'
+        $multiLineAssociative1 = [
+            'foo' => 'bar', 'baz' => 'bat',
         ];
 
         $multiLineAssociative2 = [
+            'foo'=>'bar',
+                'baz'=>'bat',
+        'bak'=>'baz'
+        ];
+
+        $multiLineAssociative3 = [
             'firstKey'        => 'bar',
             'thisIsSecondKey' => 'bat',
             'third'           => 'bat',

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -38,6 +38,8 @@ class Basic extends \Some\Other\Namespace\AbstractBasic implements \Lmc\CodingSt
 
     public function fooBar ( mixed    $foo ): mixed // FunctionDeclarationFixer
     {
+        // MagicConstantCasingFixer
+        $magicConstant = __dir__;
         $value = 5;
         // FunctionDeclarationFixer
         $function = function($foo)use($value) {
@@ -160,4 +162,10 @@ but should be heredoc instead';
         // NullableTypeDeclarationForDefaultNullValueFixer
         string $anotherNullableValue = null,
     ): void {}
+
+    // MagicMethodCasingFixer, OrderedClassElementsFixer
+    public function __ToString(): string
+    {
+        return '';
+    }
 }

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -1,8 +1,11 @@
 <?php
 
-use Bar\Foo as Foo; // NoUnneededImportAliasFixer
+namespace Lmc\CodingStandard\Integration\Fixtures;
 
-class Basic
+// NoUnneededImportAliasFixer
+use Bar\Foo as Foo;
+
+class Basic extends \Some\Other\Namespace\AbstractBasic implements \Lmc\CodingStandard\Integration\Fixtures\InterfaceFromThisNamespace // FullyQualifiedStrictTypesFixer
 {
     const FOO = 'foo'; // ClassAttributesSeparationFixer
     function isEqual($a, ? string $b): ? bool // VisibilityRequiredFixer, CompactNullableTypeDeclarationFixer

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -101,4 +101,12 @@ class Basic
     {
         return $first . $third;
     }
+
+    public function emptyFunction1(): void {
+    } // SingleLineEmptyBodyFixer
+
+    public function emptyFunction2(
+        $arg
+    ): void {
+    } // SingleLineEmptyBodyFixer
 }

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -74,4 +74,18 @@ class Basic
             'third'           => 'bat',
         ];
     }
+
+    /**
+     * Very well documented method.
+     * It tests PhpdocAlignFixer, NoSuperfluousPhpdocTagsFixer and possibly other Phpdoc rules.
+     * @param   string      $first
+     * @throws  \Exception
+     * @param   int|float   $second Second parameter does have a comment, unlike the first one.
+     * @param   string|null $third Third parameter is optional and has a default value.
+     * @return  mixed There is also information about return type.
+     */
+    public function veryWellDocumented(string $first, int|float $second, ?string $third = '3rd'): mixed
+    {
+        return $first . $third;
+    }
 }

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -55,6 +55,21 @@ class Basic extends \Some\Other\Namespace\AbstractBasic implements \Lmc\CodingSt
             $baz = join(',', ['foo', 'bar']);
         }
 
+        // HeredocIndentationFixer
+        $heredoc = <<<HEREDOC
+This is a
+multiline heredoc string. It contains $foo.
+It should be indented, though.
+HEREDOC;
+        // HeredocIndentationFixer
+        $newdoc = <<<'NEWDOC'
+This is a $newdoc, where variables are not expanded.
+NEWDOC;
+        // MultilineStringToHeredocFixer
+        $multilineString = 'This string
+spans multiple lines
+but should be heredoc instead';
+
         // SingleLineCommentSpacingFixer
         //This comment should have space on the beginning
         /*So should this one, also with space on the end*/

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -120,20 +120,6 @@ but should be heredoc instead';
         ];
     }
 
-    /**
-     * Very well documented method.
-     * It tests PhpdocAlignFixer, NoSuperfluousPhpdocTagsFixer and possibly other Phpdoc rules.
-     * @param   string      $first
-     * @throws  \Exception
-     * @param   int|float   $second Second parameter does have a comment, unlike the first one.
-     * @param   string|null $third Third parameter is optional and has a default value.
-     * @return  mixed There is also information about return type.
-     */
-    public function veryWellDocumented(string $first, int|float $second, ?string $third = '3rd'): mixed
-    {
-        return $first . $third;
-    }
-
     public function emptyFunction1(): void {
     } // SingleLineEmptyBodyFixer
 

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -1,5 +1,7 @@
 <?php
 
+use Bar\Foo as Foo; // NoUnneededImportAliasFixer
+
 class Basic
 {
     const FOO = 'foo'; // ClassAttributesSeparationFixer
@@ -19,6 +21,9 @@ class Basic
         $className = DateTime :: class;
         // ClassReferenceNameCasingFixer
         $date = new \datetime();
+
+        $aliasedClass = new Foo();
+
         // SingleSpaceAfterConstructFixer, StrictComparisonFixer
         if ($a == $b || $bazLength != 3) { return  true; }
         return false; // BlankLineBeforeStatementFixer

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -61,6 +61,14 @@ class Basic extends \Some\Other\Namespace\AbstractBasic implements \Lmc\CodingSt
         $text = 'foo';
         $text = $text . 'bar'; // LongToShorthandOperatorFixer
 
+        switch ($i) {
+            case (1): // NoUnneededControlParenthesesFixer
+                $i++;
+                break;
+            default:
+                break;
+        }
+
         // HeredocIndentationFixer
         $heredoc = <<<HEREDOC
 This is a

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -81,14 +81,6 @@ HEREDOC;
         $newdoc = <<<'NEWDOC'
 This is a $newdoc, where variables are not expanded.
 NEWDOC;
-        // MultilineStringToHeredocFixer
-        $multilineString = 'This string
-spans multiple lines
-but should be heredoc instead';
-
-        // SingleLineCommentSpacingFixer
-        //This comment should have space on the beginning
-        /*So should this one, also with space on the end*/
 
         // TernaryToElvisOperatorFixer
         return ($foo ? $foo : 'not true');

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -167,4 +167,8 @@ but should be heredoc instead';
             2
         );
     }
+
+    // NullableTypeDeclarationFixer
+    public function withParameters(null|string $nullableValue): void
+    {}
 }

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -109,4 +109,30 @@ class Basic
         $arg
     ): void {
     } // SingleLineEmptyBodyFixer
+
+    // TrailingCommaInMultilineFixer
+    public function multiline(
+        $arg1,
+            $arg2,
+        $arg3
+    ): void
+    {
+        // TrailingCommaInMultilineFixer
+        $isSet = isset(
+            $arg1,
+            $arg2,
+            $arg3
+        );
+
+        $sprintf = sprintf(
+            '%s%s',
+            'bar',
+            'baz'
+        );
+
+        foo(
+            1,
+            2
+        );
+    }
 }

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -40,6 +40,10 @@ class Basic
             $baz = join(',', ['foo', 'bar']);
         }
 
+        // SingleLineCommentSpacingFixer
+        //This comment should have space on the beginning
+        /*So should this one, also with space on the end*/
+
         // TernaryToElvisOperatorFixer
         return ($foo ? $foo : 'not true');
     }

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -27,8 +27,10 @@ class Basic
          * Phpdoc used instead of plain comment
          */
         if ($foo === 'bar') {
-            $baz = 'bat';
+            // NoAliasFunctionsFixer
+            $baz = join(',', ['foo', 'bar']);
         }
+
         // TernaryToElvisOperatorFixer
         return ($foo ? $foo : 'not true');
     }

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -168,7 +168,10 @@ but should be heredoc instead';
         );
     }
 
-    // NullableTypeDeclarationFixer
-    public function withParameters(null|string $nullableValue): void
-    {}
+    public function withParameters(
+        // NullableTypeDeclarationFixer
+        null|string $nullableValue,
+        // NullableTypeDeclarationForDefaultNullValueFixer
+        string $anotherNullableValue = null,
+    ): void {}
 }

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -33,8 +33,16 @@ class Basic
 
     public const MY_PUBLIC_CONST = 333; // OrderedClassElementsFixer
 
-    public function fooBar(mixed $foo): mixed
+    public function fooBar ( mixed    $foo ): mixed // FunctionDeclarationFixer
     {
+        $value = 5;
+        // FunctionDeclarationFixer
+        $function = function($foo)use($value) {
+            return $foo + $value;
+        };
+        // FunctionDeclarationFixer
+        $fn = fn ($foo) => $foo + $value;
+
         // PhpdocToCommentFixer
         /**
          * Phpdoc used instead of plain comment

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -17,6 +17,8 @@ class Basic
         $useStrictParam = in_array(1337, $fooBar);
         // NoSpaceAroundDoubleColonFixer
         $className = DateTime :: class;
+        // ClassReferenceNameCasingFixer
+        $date = new \datetime();
         // SingleSpaceAfterConstructFixer, StrictComparisonFixer
         if ($a == $b || $bazLength != 3) { return  true; }
         return false; // BlankLineBeforeStatementFixer

--- a/tests/Integration/Fixtures/Basic.wrong.php.inc
+++ b/tests/Integration/Fixtures/Basic.wrong.php.inc
@@ -55,6 +55,12 @@ class Basic extends \Some\Other\Namespace\AbstractBasic implements \Lmc\CodingSt
             $baz = join(',', ['foo', 'bar']);
         }
 
+        $i = 3;
+        $i = $i + 6; // LongToShorthandOperatorFixer
+        $i = $i * 2; // LongToShorthandOperatorFixer
+        $text = 'foo';
+        $text = $text . 'bar'; // LongToShorthandOperatorFixer
+
         // HeredocIndentationFixer
         $heredoc = <<<HEREDOC
 This is a

--- a/tests/Integration/Fixtures/NewPhpFeatures.correct.php.inc
+++ b/tests/Integration/Fixtures/NewPhpFeatures.correct.php.inc
@@ -20,6 +20,9 @@ class NewPhpFeatures
         $dateOrNull = $this->mayReturnDateTimeOrNull();
         $timestamp = $dateOrNull?->getTimestamp(); // RequireNullSafeObjectOperatorSniff
 
+        // AssignNullCoalescingToCoalesceEqualFixer
+        $name = $_GET['name'] ?? 'default';
+
         return $foo;
     }
 

--- a/tests/Integration/Fixtures/NewPhpFeatures.correct.php.inc
+++ b/tests/Integration/Fixtures/NewPhpFeatures.correct.php.inc
@@ -9,7 +9,7 @@ class NewPhpFeatures
     }
 
     public function php80features(
-        string|bool $foo, // UnionTypeHintFormatSniff
+        string|bool $foo, // TypesSpacesFixer
         int $bar, // RequireTrailingCommaInDeclarationSniff
     ): string|bool {
         $value = mt_rand(

--- a/tests/Integration/Fixtures/NewPhpFeatures.correct.php.inc
+++ b/tests/Integration/Fixtures/NewPhpFeatures.correct.php.inc
@@ -29,4 +29,18 @@ class NewPhpFeatures
     {
         return null;
     }
+
+    // AttributeEmptyParenthesesFixer
+    #[SomeFunctionAttribute]
+    #[AnotherAttribute('bar')]
+    #[AnotherAttribute]
+    #[First]
+    #[Second]
+    public function functionWithAttributes(
+        // MethodArgumentSpaceFixer
+        #[ParamAttribute]
+        #[AnotherAttribute('foo')]
+        string $foo,
+        string $bar,
+    ): void {}
 }

--- a/tests/Integration/Fixtures/NewPhpFeatures.correct.php.inc
+++ b/tests/Integration/Fixtures/NewPhpFeatures.correct.php.inc
@@ -5,8 +5,7 @@ namespace Lmc\CodingStandard\Integration\Fixtures;
 class NewPhpFeatures
 {
     public function __construct(private string $someString) // RequireConstructorPropertyPromotionSniff
-    {
-    }
+    {}
 
     public function php80features(
         string|bool $foo, // TypesSpacesFixer

--- a/tests/Integration/Fixtures/NewPhpFeatures.wrong.php.inc
+++ b/tests/Integration/Fixtures/NewPhpFeatures.wrong.php.inc
@@ -33,4 +33,15 @@ class NewPhpFeatures
     {
         return null;
     }
+
+    // AttributeEmptyParenthesesFixer
+    #[SomeFunctionAttribute()]
+    #[AnotherAttribute('bar')]#[AnotherAttribute()]
+
+    #[First, Second]
+    public function functionWithAttributes(
+        // MethodArgumentSpaceFixer
+        #[ParamAttribute] #[AnotherAttribute('foo')] string $foo,
+        string $bar,
+    ): void {}
 }

--- a/tests/Integration/Fixtures/NewPhpFeatures.wrong.php.inc
+++ b/tests/Integration/Fixtures/NewPhpFeatures.wrong.php.inc
@@ -12,7 +12,7 @@ class NewPhpFeatures
     }
 
     public function php80features(
-        string | bool $foo, // UnionTypeHintFormatSniff
+        string | bool $foo, // TypesSpacesFixer
         int $bar // RequireTrailingCommaInDeclarationSniff
     ): string | bool {
         $value = mt_rand(

--- a/tests/Integration/Fixtures/NewPhpFeatures.wrong.php.inc
+++ b/tests/Integration/Fixtures/NewPhpFeatures.wrong.php.inc
@@ -23,6 +23,9 @@ class NewPhpFeatures
         $dateOrNull = $this->mayReturnDateTimeOrNull();
         $timestamp = $dateOrNull !== null ? $dateOrNull->getTimestamp() : null; // RequireNullSafeObjectOperatorSniff
 
+        // AssignNullCoalescingToCoalesceEqualFixer
+        $name = isset($_GET['name']) ? $_GET['name'] : 'default';
+
         return $foo;
     }
 

--- a/tests/Integration/Fixtures/Php81.correct.php.inc
+++ b/tests/Integration/Fixtures/Php81.correct.php.inc
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\CodingStandard\Integration\Fixtures;
+
+class Php81
+{
+    public function php81features(): void
+    {
+        // OctalNotationFixer
+        $numberInOctalNotation = 0o123;
+    }
+}

--- a/tests/Integration/Fixtures/Php81.wrong.php.inc
+++ b/tests/Integration/Fixtures/Php81.wrong.php.inc
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\CodingStandard\Integration\Fixtures;
+
+class Php81
+{
+    public function php81features(): void
+    {
+        // OctalNotationFixer
+        $numberInOctalNotation = 0123;
+    }
+}

--- a/tests/Integration/Fixtures/Php82.correct.php.inc
+++ b/tests/Integration/Fixtures/Php82.correct.php.inc
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\CodingStandard\Integration\Fixtures;
+
+class Php82
+{
+    public function php82features(): void
+    {
+        $name = 'John';
+        $complexString = "Hello {$name}!";
+    }
+}

--- a/tests/Integration/Fixtures/Php82.wrong.php.inc
+++ b/tests/Integration/Fixtures/Php82.wrong.php.inc
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\CodingStandard\Integration\Fixtures;
+
+class Php82
+{
+    public function php82features(): void
+    {
+        $name = 'John';
+        $complexString = "Hello ${name}!";
+    }
+}

--- a/tests/Integration/Fixtures/PhpDoc.correct.php.inc
+++ b/tests/Integration/Fixtures/PhpDoc.correct.php.inc
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\CodingStandard\Integration\Fixtures;
+
+class PhpDoc
+{
+    // PhpdocToPropertyTypeFixer, PropertyTypeHintSniff
+    private int $integerValue = 3;
+    private $undefinedTypeValue = 3;
+    private mixed $undeclaredMixedType;
+    private \DateTimeImmutable $nonScalarType;
+
+    /**
+     * Very well documented method.
+     * It tests PhpdocAlignFixer, NoSuperfluousPhpdocTagsFixer and possibly other Phpdoc rules.
+     * @param int|float $second Second parameter does have a comment, unlike the first one.
+     * @param string|null $third Third parameter is optional and has a default value.
+     * @return mixed There is also information about return type.
+     * @throws \Exception
+     */
+    public function veryWellDocumented(string $first, int|float $second, ?string $third = '3rd'): mixed
+    {
+        return $first . $third;
+    }
+}

--- a/tests/Integration/Fixtures/PhpDoc.correct.php.inc
+++ b/tests/Integration/Fixtures/PhpDoc.correct.php.inc
@@ -22,4 +22,17 @@ class PhpDoc
     {
         return $first . $third;
     }
+
+    public function methodWithTypesInTypeHints(int $value, mixed $mixedType): bool
+    {
+        return $value > 3 ? true : false;
+    }
+
+    /**
+     * @param string $stringParam This phpdoc should be preserved, because it contains some comment for $stringParam.
+     */
+    public function methodWithMeaningfulParamComment(int $intParam, string $stringParam): void
+    {
+        // Do nothing.
+    }
 }

--- a/tests/Integration/Fixtures/PhpDoc.correct.php.inc
+++ b/tests/Integration/Fixtures/PhpDoc.correct.php.inc
@@ -12,7 +12,9 @@ class PhpDoc
 
     /**
      * Very well documented method.
-     * It tests PhpdocAlignFixer, NoSuperfluousPhpdocTagsFixer and possibly other Phpdoc rules.
+     * It tests PhpdocAlignFixer, NoSuperfluousPhpdocTagsFixer, PhpdocTrimConsecutiveBlankLineSeparationFixer
+     * and possibly other Phpdoc rules.
+     *
      * @param int|float $second Second parameter does have a comment, unlike the first one.
      * @param string|null $third Third parameter is optional and has a default value.
      * @return mixed There is also information about return type.

--- a/tests/Integration/Fixtures/PhpDoc.wrong.php.inc
+++ b/tests/Integration/Fixtures/PhpDoc.wrong.php.inc
@@ -15,7 +15,11 @@ class PhpDoc
 
     /**
      * Very well documented method.
-     * It tests PhpdocAlignFixer, NoSuperfluousPhpdocTagsFixer and possibly other Phpdoc rules.
+     * It tests PhpdocAlignFixer, NoSuperfluousPhpdocTagsFixer, PhpdocTrimConsecutiveBlankLineSeparationFixer
+     * and possibly other Phpdoc rules.
+     *
+     *
+     *
      * @param   string      $first
      * @throws  \Exception
      * @param   int|float   $second Second parameter does have a comment, unlike the first one.

--- a/tests/Integration/Fixtures/PhpDoc.wrong.php.inc
+++ b/tests/Integration/Fixtures/PhpDoc.wrong.php.inc
@@ -26,4 +26,24 @@ class PhpDoc
     {
         return $first . $third;
     }
+
+    /**
+     * @param int $value
+     * @param mixed $mixedType
+     * @return bool
+     */
+    public function methodWithTypesInTypeHints($value, $mixedType)
+    {
+        return $value > 3 ? true : false;
+    }
+
+    /**
+     * @param int $intParam
+     * @param string $stringParam This phpdoc should be preserved, because it contains some comment for $stringParam.
+     * @return void
+     */
+    public function methodWithMeaningfulParamComment(int $intParam, string $stringParam): void
+    {
+        // Do nothing.
+    }
 }

--- a/tests/Integration/Fixtures/PhpDoc.wrong.php.inc
+++ b/tests/Integration/Fixtures/PhpDoc.wrong.php.inc
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\CodingStandard\Integration\Fixtures;
+
+class PhpDoc
+{
+    // PhpdocToPropertyTypeFixer, PropertyTypeHintSniff
+    /** @var int */
+    private $integerValue = 3;
+    private $undefinedTypeValue = 3;
+    /** @var mixed */
+    private $undeclaredMixedType;
+    /** @var \DateTimeImmutable */
+    private $nonScalarType;
+
+    /**
+     * Very well documented method.
+     * It tests PhpdocAlignFixer, NoSuperfluousPhpdocTagsFixer and possibly other Phpdoc rules.
+     * @param   string      $first
+     * @throws  \Exception
+     * @param   int|float   $second Second parameter does have a comment, unlike the first one.
+     * @param   string|null $third Third parameter is optional and has a default value.
+     * @return  mixed There is also information about return type.
+     */
+    public function veryWellDocumented(string $first, int|float $second, ?string $third = '3rd'): mixed
+    {
+        return $first . $third;
+    }
+}

--- a/tests/Integration/Fixtures/PhpUnit.correct.php.inc
+++ b/tests/Integration/Fixtures/PhpUnit.correct.php.inc
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\CodingStandard\Integration\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+
+class PhpUnit extends TestCase
+{
+    // PhpUnitSetUpTearDownVisibilityFixer
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testShouldDoSomething(): void
+    {
+        $data = true;
+
+        // PhpUnitConstructFixer
+        $this->assertTrue($data);
+
+        // PhpUnitDedicateAssertFixer
+        $this->assertStringContainsString('o', 'foo');
+
+        $this->assertSame(1, 2);
+        // PhpUnitTestCaseStaticMethodCallsFixer
+        $this->assertSame(1, 2);
+        // PhpUnitTestCaseStaticMethodCallsFixer
+        $this->assertSame(1, 2);
+    }
+}

--- a/tests/Integration/Fixtures/PhpUnit.correct.php.inc
+++ b/tests/Integration/Fixtures/PhpUnit.correct.php.inc
@@ -31,4 +31,9 @@ class PhpUnit extends TestCase
         // PhpUnitTestCaseStaticMethodCallsFixer
         $this->assertSame(1, 2);
     }
+
+    public function testMethodName(): void // PhpUnitMethodCasingFixer
+    {
+        $this->assertTrue(true);
+    }
 }

--- a/tests/Integration/Fixtures/PhpUnit.correct.php.inc
+++ b/tests/Integration/Fixtures/PhpUnit.correct.php.inc
@@ -4,6 +4,9 @@ namespace Lmc\CodingStandard\Integration\Fixtures;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \Lmc\CodingStandard\Integration\Fixtures\MyClass
+ */
 class PhpUnit extends TestCase
 {
     // PhpUnitSetUpTearDownVisibilityFixer

--- a/tests/Integration/Fixtures/PhpUnit.wrong.php.inc
+++ b/tests/Integration/Fixtures/PhpUnit.wrong.php.inc
@@ -4,6 +4,9 @@ namespace Lmc\CodingStandard\Integration\Fixtures;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers Lmc\CodingStandard\Integration\Fixtures\MyClass
+ */
 class PhpUnit extends TestCase
 {
     // PhpUnitSetUpTearDownVisibilityFixer

--- a/tests/Integration/Fixtures/PhpUnit.wrong.php.inc
+++ b/tests/Integration/Fixtures/PhpUnit.wrong.php.inc
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\CodingStandard\Integration\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+
+class PhpUnit extends TestCase
+{
+    // PhpUnitSetUpTearDownVisibilityFixer
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testShouldDoSomething(): void
+    {
+        $data = true;
+
+        // PhpUnitConstructFixer
+        $this->assertSame(true, $data);
+
+        // PhpUnitDedicateAssertFixer
+        $this->assertTrue(str_contains('foo', 'o'));
+
+        $this->assertSame(1, 2);
+        // PhpUnitTestCaseStaticMethodCallsFixer
+        self::assertSame(1, 2);
+        // PhpUnitTestCaseStaticMethodCallsFixer
+        static::assertSame(1, 2);
+    }
+}

--- a/tests/Integration/Fixtures/PhpUnit.wrong.php.inc
+++ b/tests/Integration/Fixtures/PhpUnit.wrong.php.inc
@@ -31,4 +31,9 @@ class PhpUnit extends TestCase
         // PhpUnitTestCaseStaticMethodCallsFixer
         static::assertSame(1, 2);
     }
+
+    public function test_method_name(): void // PhpUnitMethodCasingFixer
+    {
+        $this->assertTrue(true);
+    }
 }


### PR DESCRIPTION
This adds many fixers added to php-cs-fixer in releases from last years. See #94.

Should not be merged to main branch before version 4.0 is released, to make these fixers included in 4.1.