### PR TITLE
BREAKING CHANGE: Remove ecs-8.x.php files to simplify configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,24 +26,12 @@ use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 return ECSConfig::configure()
     ->withPaths([__DIR__ . '/src', __DIR__ . '/tests']) // optionally add 'config' or other directories with PHP files
-    ->withRootFiles() // to include ecs.php and all other php files in the root directory
+    ->withRootFiles() // to also check ecs.php and all other php files in the root directory
     ->withSets(
         [
             __DIR__ . '/vendor/lmc/coding-standard/ecs.php',
         ]
     );
-    
-    // By default, only checks compatible with PHP 8.0 are enabled.
-    // Depending on the lowest PHP version your project needs to support, you can enable additional checks.
-
-    // Import one of ecs-8.1.php, ecs-8.2.php or ecs-8.3.php. Use only one additional file (for the highest possible
-    // PHP version), the configs for previous versions are automatically included.
-    //->withSets(
-    //    [
-    //        __DIR__ . '/vendor/lmc/coding-standard/ecs.php',
-    //        __DIR__ . '/vendor/lmc/coding-standard/ecs-8.3.php',
-    //    ]
-    //);
 ```
 
 2. Run the check command

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
             "vendor/bin/ecs check --config=ecs-internal.php --ansi --fix"
         ],
         "lint": [
-            "vendor/bin/parallel-lint -j 10 -e php ./src ./tests ecs.php ecs-8.1.php ecs-8.2.php ecs-8.3.php",
+            "vendor/bin/parallel-lint -j 10 -e php ./src ./tests ecs.php",
             "@composer validate",
             "@composer normalize --dry-run"
         ],

--- a/ecs-8.1.php
+++ b/ecs-8.1.php
@@ -1,5 +1,0 @@
-<?php declare(strict_types=1);
-
-use Symplify\EasyCodingStandard\Config\ECSConfig;
-
-return ECSConfig::configure();

--- a/ecs-8.2.php
+++ b/ecs-8.2.php
@@ -1,6 +1,0 @@
-<?php declare(strict_types=1);
-
-use Symplify\EasyCodingStandard\Config\ECSConfig;
-
-return ECSConfig::configure()
-    ->withSets([__DIR__ . '/ecs-8.1.php']);

--- a/ecs-8.3.php
+++ b/ecs-8.3.php
@@ -1,6 +1,0 @@
-<?php declare(strict_types=1);
-
-use Symplify\EasyCodingStandard\Config\ECSConfig;
-
-return ECSConfig::configure()
-    ->withSets([__DIR__ . '/ecs-8.2.php']);


### PR DESCRIPTION
I tend to believe we no longer need these files with extra config for specific PHP version:

- There aren't any check in them
- Fixers which depends on some PHP version (eg. they require PHP 8.1 features) have version detection build inside them and they don't run if they detect unsupported PHP version
- In case we would need such feature to make PHP version dependent config, we can do it directly in the ecs.php file (`if (PHP_VERSION >= xxx) { ... })`

So because of the near-to-zero value and to make the configuration simpler I suggest removing these extra files.