### PR TITLE
Refactor: Remove nette/utils dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     "require": {
         "php": "^8.0",
         "friendsofphp/php-cs-fixer": "^3.47.1",
-        "nette/utils": "^3.2",
         "slevomat/coding-standard": "^8.6",
         "squizlabs/php_codesniffer": "^3.9",
         "symplify/easy-coding-standard": "^12.1.9"

--- a/src/Sniffs/Naming/AbstractClassNameSniff.php
+++ b/src/Sniffs/Naming/AbstractClassNameSniff.php
@@ -28,7 +28,6 @@
 
 namespace Lmc\CodingStandard\Sniffs\Naming;
 
-use Nette\Utils\Strings;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
@@ -70,7 +69,7 @@ final class AbstractClassNameSniff implements Sniff
             return true;
         }
 
-        return Strings::startsWith($className, 'Abstract');
+        return str_starts_with($className, 'Abstract');
     }
 
     private function isClassAbstract(): bool

--- a/src/Sniffs/Naming/ClassNameSuffixByParentSniff.php
+++ b/src/Sniffs/Naming/ClassNameSuffixByParentSniff.php
@@ -30,7 +30,6 @@ namespace Lmc\CodingStandard\Sniffs\Naming;
 
 use Lmc\CodingStandard\Helper\Naming;
 use Lmc\CodingStandard\Helper\SniffClassWrapper;
-use Nette\Utils\Strings;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
@@ -101,7 +100,7 @@ final class ClassNameSuffixByParentSniff implements Sniff
 
             // the class that implements $currentParentType, should end with $suffix
             $suffix = $this->resolveExpectedSuffix($parentType);
-            if (Strings::endsWith($className, $suffix)) {
+            if (str_ends_with($className, $suffix)) {
                 continue;
             }
 
@@ -123,12 +122,12 @@ final class ClassNameSuffixByParentSniff implements Sniff
      */
     private function resolveExpectedSuffix(string $parentType): string
     {
-        if (Strings::endsWith($parentType, 'Interface')) {
-            $parentType = Strings::substring($parentType, 0, -mb_strlen('Interface'));
+        if (str_ends_with($parentType, 'Interface')) {
+            $parentType = mb_substr($parentType, 0, -mb_strlen('Interface'), 'UTF-8');
         }
 
-        if (Strings::startsWith($parentType, 'Abstract')) {
-            $parentType = Strings::substring($parentType, mb_strlen('Abstract'));
+        if (str_starts_with($parentType, 'Abstract')) {
+            $parentType = mb_substr($parentType, mb_strlen('Abstract'), null, 'UTF-8');
         }
 
         return $parentType;

--- a/src/Sniffs/Naming/InterfaceNameSniff.php
+++ b/src/Sniffs/Naming/InterfaceNameSniff.php
@@ -28,7 +28,6 @@
 
 namespace Lmc\CodingStandard\Sniffs\Naming;
 
-use Nette\Utils\Strings;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
@@ -56,7 +55,7 @@ final class InterfaceNameSniff implements Sniff
         $this->file = $phpcsFile;
         $this->position = $stackPtr;
 
-        if (Strings::endsWith($this->getInterfaceName(), 'Interface')) {
+        if (str_ends_with($this->getInterfaceName(), 'Interface')) {
             return;
         }
 

--- a/src/Sniffs/Naming/TraitNameSniff.php
+++ b/src/Sniffs/Naming/TraitNameSniff.php
@@ -28,7 +28,6 @@
 
 namespace Lmc\CodingStandard\Sniffs\Naming;
 
-use Nette\Utils\Strings;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
@@ -56,7 +55,7 @@ final class TraitNameSniff implements Sniff
         $this->file = $phpcsFile;
         $this->position = $stackPtr;
 
-        if (Strings::endsWith($this->getTraitName(), 'Trait')) {
+        if (str_ends_with($this->getTraitName(), 'Trait')) {
             return;
         }
 


### PR DESCRIPTION
Thanks to PHP 8 new functions, we can now easily remove Nette/Utils dependency.