### PR TITLE
Feat: Remove the most risky fixers from the next version

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -69,9 +69,6 @@ use PhpCsFixer\Fixer\FunctionNotation\ImplodeCallFixer;
 use PhpCsFixer\Fixer\FunctionNotation\LambdaNotUsedImportFixer;
 use PhpCsFixer\Fixer\FunctionNotation\NoUnreachableDefaultArgumentValueFixer;
 use PhpCsFixer\Fixer\FunctionNotation\NoUselessSprintfFixer;
-use PhpCsFixer\Fixer\FunctionNotation\PhpdocToParamTypeFixer;
-use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
-use PhpCsFixer\Fixer\FunctionNotation\PhpdocToReturnTypeFixer;
 use PhpCsFixer\Fixer\FunctionNotation\ReturnTypeDeclarationFixer;
 use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
 use PhpCsFixer\Fixer\Import\NoLeadingImportSlashFixer;
@@ -133,14 +130,10 @@ use PhpCsFixer\Fixer\Whitespace\HeredocIndentationFixer;
 use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
 use PhpCsFixer\Fixer\Whitespace\NoWhitespaceInBlankLineFixer;
 use PhpCsFixer\Fixer\Whitespace\TypeDeclarationSpacesFixer;
-use SlevomatCodingStandard\Sniffs\Classes\RequireConstructorPropertyPromotionSniff;
 use SlevomatCodingStandard\Sniffs\ControlStructures\RequireNullSafeObjectOperatorSniff;
 use SlevomatCodingStandard\Sniffs\Exceptions\ReferenceThrowableOnlySniff;
 use SlevomatCodingStandard\Sniffs\Functions\RequireTrailingCommaInCallSniff;
 use SlevomatCodingStandard\Sniffs\Functions\RequireTrailingCommaInDeclarationSniff;
-use SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff;
-use SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff;
-use SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\UnionTypeHintFormatSniff;
 use Symplify\CodingStandard\Fixer\Commenting\ParamReturnAndVarTagMalformsFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
@@ -377,15 +370,6 @@ return ECSConfig::configure()
             ReferenceThrowableOnlySniff::class,
             // The @param, @return, @var and inline @var annotations should keep standard format
             ParamReturnAndVarTagMalformsFixer::class,
-            // Takes `@var` annotation of non-mixed types and adjusts accordingly the property signature.
-            PhpdocToPropertyTypeFixer::class,
-            // Takes `@param` annotations of non-mixed types and adjusts accordingly the function signature.
-            PhpdocToParamTypeFixer::class,
-            // Takes `@return` annotation of non-mixed types and adjusts accordingly the function signature.
-            PhpdocToReturnTypeFixer::class,
-            // Promote constructor properties
-            // @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5956
-            RequireConstructorPropertyPromotionSniff::class,
 
             // switch -> match
             // @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5894
@@ -393,10 +377,6 @@ return ECSConfig::configure()
             // Require \Stringable interface in classes implementing __toString() method
             // > it may probably be a phpstan rule, more than cs rule - since it needs a class hierarchy to solve this
             // @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6235
-            PropertyTypeHintSniff::class,
-
-            ParameterTypeHintSniff::class,
-            ReturnTypeHintSniff::class,
 
             // Multi-line arguments list in function/method declaration must have a trailing comma
             RequireTrailingCommaInDeclarationSniff::class,
@@ -530,18 +510,6 @@ return ECSConfig::configure()
 
         // Allow single line closures
         ScopeClosingBraceSniff::class . '.ContentBefore' => null,
-
-        // Skip unwanted rules from PropertyTypeHintSniff
-        PropertyTypeHintSniff::class . '.' . PropertyTypeHintSniff::CODE_MISSING_TRAVERSABLE_TYPE_HINT_SPECIFICATION => null,
-        PropertyTypeHintSniff::class . '.' . PropertyTypeHintSniff::CODE_MISSING_ANY_TYPE_HINT => null,
-
-        // Skip unwanted rules from ParameterTypeHintSniff
-        ParameterTypeHintSniff::class . '.' . ParameterTypeHintSniff::CODE_MISSING_TRAVERSABLE_TYPE_HINT_SPECIFICATION => null,
-        ParameterTypeHintSniff::class . '.' . ParameterTypeHintSniff::CODE_MISSING_ANY_TYPE_HINT => null,
-
-        // Skip unwanted rules from ReturnTypeHintSniff
-        ReturnTypeHintSniff::class . '.' . ReturnTypeHintSniff::CODE_MISSING_TRAVERSABLE_TYPE_HINT_SPECIFICATION => null,
-        ReturnTypeHintSniff::class . '.' . ReturnTypeHintSniff::CODE_MISSING_ANY_TYPE_HINT => null,
 
         // We use declare(strict_types=1); after opening tag
         BlankLineAfterOpeningTagFixer::class => null,

--- a/tests/Integration/Fixtures/NewPhpFeatures.correct.php.inc
+++ b/tests/Integration/Fixtures/NewPhpFeatures.correct.php.inc
@@ -4,8 +4,11 @@ namespace Lmc\CodingStandard\Integration\Fixtures;
 
 class NewPhpFeatures
 {
-    public function __construct(private string $someString) // RequireConstructorPropertyPromotionSniff
+    private string $someString;
+
+    public function __construct(string $someString)
     {
+        $this->someString = $someString;
     }
 
     public function php80features(

--- a/tests/Integration/Fixtures/NewPhpFeatures.wrong.php.inc
+++ b/tests/Integration/Fixtures/NewPhpFeatures.wrong.php.inc
@@ -6,7 +6,7 @@ class NewPhpFeatures
 {
     private string $someString;
 
-    public function __construct(string $someString) // RequireConstructorPropertyPromotionSniff
+    public function __construct(string $someString)
     {
         $this->someString = $someString;
     }


### PR DESCRIPTION
Those fixers will not be included in next release (4.0), but will be readded as part of #95 targeted to version 4.1.

This is to provide easier upgrade path for the products which would like to make more conservative two-phases upgrade (first to 4.0 mainly to change the config, then to 4.1 to fix more code issues).