### PR TITLE
Fix: Skip part of OperatorSpacingSniff because its incorrect behavior

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -486,6 +486,11 @@ return ECSConfig::configure()
         // We allow empty catch statements (but they must have comment - see EmptyCatchCommentSniff)
         EmptyStatementSniff::class . '.DetectedCatch' => null,
 
+        // Skip because of its attempts to add spaces in declare(strict_types=1); starting with ECS 12.2.0
+        // @TODO: In future ECS versions try whether its is still broken or this skip could be removed
+        OperatorSpacingSniff::class . '.NoSpaceAfter' => null,
+        OperatorSpacingSniff::class . '.NoSpaceBefore' => null,
+
         // Skip unwanted rules from DocCommentSniff
         DocCommentSniff::class . '.ContentAfterOpen' => null,
         DocCommentSniff::class . '.ContentBeforeClose' => null,


### PR DESCRIPTION
Out of nowhere (even though PHP_CodeSniffer was probalby not updated in new ECS release - but maybe it was, we don't know) the sniff started to add spaces in every `declare` statement.

```diff
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
```

... which is against PER 2.