### PR TITLE
Feat: Remove RequireTrailingCommaInCallSniff

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "friendsofphp/php-cs-fixer": "^3.47.1",
         "slevomat/coding-standard": "^8.6",
         "squizlabs/php_codesniffer": "^3.9",
-        "symplify/easy-coding-standard": "^12.1.9"
+        "symplify/easy-coding-standard": "^12.2.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.42.0",

--- a/ecs.php
+++ b/ecs.php
@@ -162,7 +162,6 @@ use SlevomatCodingStandard\Sniffs\Attributes\DisallowMultipleAttributesPerLineSn
 use SlevomatCodingStandard\Sniffs\Classes\RequireConstructorPropertyPromotionSniff;
 use SlevomatCodingStandard\Sniffs\ControlStructures\RequireNullSafeObjectOperatorSniff;
 use SlevomatCodingStandard\Sniffs\Exceptions\ReferenceThrowableOnlySniff;
-use SlevomatCodingStandard\Sniffs\Functions\RequireTrailingCommaInCallSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff;
@@ -445,8 +444,6 @@ return ECSConfig::configure()
             // Promote constructor properties
             // For php-cs-fixer implementation @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5956
             RequireConstructorPropertyPromotionSniff::class,
-            // Multi-line arguments list in function/method call must have a trailing comma
-            RequireTrailingCommaInCallSniff::class, // TODO: will be redundant after https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7989 is merged and released
             // Use `null-safe` operator `?->` where possible
             RequireNullSafeObjectOperatorSniff::class,
         ],


### PR DESCRIPTION
RequireTrailingCommaInCallSniff is redundant thanks to TrailingCommaInMultilineFixer, which [now supports](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7989) language constructs - what was its only reals difference from RequireTrailingCommaInCallSniff.