### PR TITLE
Fix: Disable incorrectly behaving PhpdocAlignFixer for multiline descriptions

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -522,7 +522,8 @@ return ECSConfig::configure()
         'remove_inheritdoc' => true, // remove @inheritDoc tags
     ])
     // All items of the given PHPDoc tags must be left-aligned.
-    ->withConfiguredRule(PhpdocAlignFixer::class, ['align' => 'left'])
+    // @TODO: Re-enable if https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8052 is fixed
+    //->withConfiguredRule(PhpdocAlignFixer::class, ['align' => 'left'])
     // Annotations in PHPDoc should be ordered in defined sequence.
     ->withConfiguredRule(PhpdocOrderFixer::class, ['order' => ['param', 'return', 'throws']])
     // Order phpdoc tags by value.

--- a/tests/Integration/Fixtures/PhpDoc.correct.php.inc
+++ b/tests/Integration/Fixtures/PhpDoc.correct.php.inc
@@ -16,7 +16,9 @@ class PhpDoc
      * and possibly other Phpdoc rules.
      *
      * @param int|float $second Second parameter does have a comment, unlike the first one.
-     * @param string|null $third Third parameter is optional and has a default value.
+     * @param string|null $third Third parameter is optional and has a default value and multilne comment. Lorem
+     * ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec purus nec nunc ultricies ultricies.
+     * Nullam nec purus nec nunc ultricies ultricies. Nullam nec purus nec nunc ultricies ultricies.
      * @return mixed There is also information about return type.
      * @throws \Exception
      */

--- a/tests/Integration/Fixtures/PhpDoc.wrong.php.inc
+++ b/tests/Integration/Fixtures/PhpDoc.wrong.php.inc
@@ -23,7 +23,9 @@ class PhpDoc
      * @param   string      $first
      * @throws  \Exception
      * @param   int|float   $second Second parameter does have a comment, unlike the first one.
-     * @param   string|null $third Third parameter is optional and has a default value.
+     * @param   string|null $third Third parameter is optional and has a default value and multilne comment. Lorem
+     * ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec purus nec nunc ultricies ultricies.
+     * Nullam nec purus nec nunc ultricies ultricies. Nullam nec purus nec nunc ultricies ultricies.
      * @return  mixed There is also information about return type.
      */
     public function veryWellDocumented(string $first, int|float $second, ?string $third = '3rd'): mixed

--- a/tests/Integration/Fixtures/PhpDoc.wrong.php.inc
+++ b/tests/Integration/Fixtures/PhpDoc.wrong.php.inc
@@ -20,13 +20,13 @@ class PhpDoc
      *
      *
      *
-     * @param   string      $first
-     * @throws  \Exception
-     * @param   int|float   $second Second parameter does have a comment, unlike the first one.
-     * @param   string|null $third Third parameter is optional and has a default value and multilne comment. Lorem
+     * @param string $first
+     * @throws \Exception
+     * @param int|float $second Second parameter does have a comment, unlike the first one.
+     * @param string|null $third Third parameter is optional and has a default value and multilne comment. Lorem
      * ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec purus nec nunc ultricies ultricies.
      * Nullam nec purus nec nunc ultricies ultricies. Nullam nec purus nec nunc ultricies ultricies.
-     * @return  mixed There is also information about return type.
+     * @return mixed There is also information about return type.
      */
     public function veryWellDocumented(string $first, int|float $second, ?string $third = '3rd'): mixed
     {


### PR DESCRIPTION
Ref. https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8052

The check aligns multiline descriptions vertically, with no option to disable this behavior which we don't want. So I have disabled the check.

I also have to remove related example in tests. Meaning we will now no longer check for correct spacing in phpdocs :shrug: .