### PR TITLE
Deps: Temporarily restrict php-cs-fixer 3.65.0 until fix for nullable decalaration is released

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     ],
     "require": {
         "php": "^8.0",
-        "friendsofphp/php-cs-fixer": "^3.47.1",
+        "friendsofphp/php-cs-fixer": "^3.47.1 !=3.65.0",
         "slevomat/coding-standard": "^8.6",
         "squizlabs/php_codesniffer": "^3.9",
-        "symplify/easy-coding-standard": "^12.2.0"
+        "symplify/easy-coding-standard": "^12.2.0 <12.4"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.42.0",


### PR DESCRIPTION
Php-cs-fixer 3.65.0 (included in ecs 12.4+) contains broken `NullableTypeDeclarationFixer,` which could lead to syntax error in code.  It also cause unit tests to fail.
See https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8330 for the bug

This should be fixed in next php-cs-fixer release (there is already a [PR with a fix](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8331)), then we can remove the version restriction.